### PR TITLE
update default configs with csolution commands (1.47 and later)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,16 @@
                 "--target",
                 "${command:cmsis-csolution.getDeviceName}",
                 "--pack",
-                "<Enter absolute path to target device DFP>",
+                "${command:cmsis-csolution.getDfpPath}",
+                "--cbuild-run",
+                "${command:cmsis-csolution.getCbuildRunPath}",
                 "--port",
                 "3333"
               ],
               "port": "3333"
+            },
+            "cmsis": {
+              "cbuildRunPath": "${command:cmsis-csolution.getCbuildRunPath}"
             }
           }
         ],
@@ -97,11 +102,16 @@
                   "--target",
                   "^\"\\${command:cmsis-csolution.getDeviceName}\"",
                   "--pack",
-                  "<Enter absolute path to target device DFP>",
+                  "^\"\\${command:cmsis-csolution.getDfpPath}\"",
+                  "--cbuild-run",
+                  "^\"\\${command:cmsis-csolution.getCbuildRunPath}\"",
                   "--port",
                   "3333"
                 ],
                 "port": "3333"
+              },
+              "cmsis": {
+                "cbuildRunPath": "^\"\\${command:cmsis-csolution.getCbuildRunPath}\""
               }
             }
           }


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Added new commands to default configurations.
  - `${command:cmsis-csolution.getDfpPath}`
  - `${command:cmsis-csolution.getCbuildRunPath}`
- Added `cmsis`->`cbuildRunPath` setting to default configurations.
- Requires Arm CMSIS Solution extension v1.47.0 and later.

ToDo: Add config resolver to automatically expand settings to gdb server `serverParameters` on debug launch to reduce duplication. Will become a separate PR that adds an initial configuration provider. Stay tuned.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
