### PR TITLE
Added defaults for J-Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,11 @@
                 "${command:cmsis-csolution.getDeviceName}",
                 "--pack",
                 "${command:cmsis-csolution.getDfpPath}",
-                "--cbuild-run",
-                "${command:cmsis-csolution.getCbuildRunPath}",
                 "--port",
-                "3333"
+                "3333",
+                "!!!REMOVE THIS AND FOLLOWING NOT YET SUPPORTED OPTIONS!!!",
+                "--cbuild-run",
+                "${command:cmsis-csolution.getCbuildRunPath}"
               ],
               "port": "3333"
             },
@@ -107,10 +108,11 @@
                   "^\"\\${command:cmsis-csolution.getDeviceName}\"",
                   "--pack",
                   "^\"\\${command:cmsis-csolution.getDfpPath}\"",
-                  "--cbuild-run",
-                  "^\"\\${command:cmsis-csolution.getCbuildRunPath}\"",
                   "--port",
-                  "3333"
+                  "3333",
+                  "!!!REMOVE THIS AND FOLLOWING NOT YET SUPPORTED OPTIONS!!!",
+                  "--cbuild-run",
+                  "^\"\\${command:cmsis-csolution.getCbuildRunPath}\""
                 ],
                 "port": "3333"
               },


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
N/A

## Changes
<!-- List the changes this PR introduces -->

- Added default configs for J-Link.
- Went for another pseudo debugger type `cmsis-debug-jlink` to allow a J-Link specific initial config. To revisit if we even want that.

ToDo: Reduce default configs with logic in extension.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
![image](https://github.com/user-attachments/assets/785ecfaf-9969-4f68-8159-767243d2075c)

![image](https://github.com/user-attachments/assets/6ac4498d-61a9-4f44-b901-ced80b295917)

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
