### PR TITLE
Rename `cbuildRunPath` to `cbuildRunFile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
               "port": "3333"
             },
             "cmsis": {
-              "cbuildRunPath": "${command:cmsis-csolution.getCbuildRunPath}"
+              "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}"
             }
           }
         ],
@@ -93,7 +93,7 @@
                 "port": "3333"
               },
               "cmsis": {
-                "cbuildRunPath": "^\"\\${command:cmsis-csolution.getCbuildRunPath}\""
+                "cbuildRunFile": "^\"\\${command:cmsis-csolution.getCbuildRunFile}\""
               }
             }
           }
@@ -193,7 +193,7 @@
                 "description": "Configures CMSIS Debugger settings.",
                 "additionalProperties": false,
                 "properties": {
-                  "cbuildRunPath": {
+                  "cbuildRunFile": {
                     "type": "string",
                     "description": "Path to *.cbuild-run.yml debug configuration file generated with CMSIS-Toolbox."
                   }
@@ -209,7 +209,7 @@
                 "description": "Configures CMSIS Debugger settings.",
                 "additionalProperties": false,
                 "properties": {
-                  "cbuildRunPath": {
+                  "cbuildRunFile": {
                     "type": "string",
                     "description": "Path to *.cbuild-run.yml debug configuration file generated with CMSIS-Toolbox."
                   }

--- a/src/debug-configuration/gdbtarget-configuration.ts
+++ b/src/debug-configuration/gdbtarget-configuration.ts
@@ -57,7 +57,7 @@ interface TargetConfiguration {
 };
 
 interface CMSISConfiguration {
-    cbuildRunPath: string;
+    cbuildRunFile: string;
 }
 
 export interface GDBTargetConfiguration extends vscode.DebugConfiguration {

--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
@@ -62,10 +62,10 @@ export class PyocdConfigurationProvider implements vscode.DebugConfigurationProv
         }
         // cbuild-run (ToDo: comment in the code when pyOCD supports it)
         /*
-        const cbuildRunPath = debugConfiguration.cmsis?.cbuildRunPath;
-        if (await this.shouldAppendParam(parameters, '--cbuild-run') && cbuildRunPath) {
+        const cbuildRunFile = debugConfiguration.cmsis?.cbuildRunFile;
+        if (await this.shouldAppendParam(parameters, '--cbuild-run') && cbuildRunFile) {
             parameters.push('--cbuild-run');
-            parameters.push(`${cbuildRunPath}`);
+            parameters.push(`${cbuildRunFile}`);
         }
         */
         return debugConfiguration;


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Rename `cbuildRunPath` to `cbuildRunFile` as per https://github.com/ARM-software/vscode-cmsis-csolution/issues/188#issuecomment-2663352843

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
