### PR TITLE
Remove target platforms without pyOCD builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/blocking_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/blocking_bug_report.yml
@@ -49,13 +49,9 @@ body:
           required: false
         - label: Windows amd64
           required: false
-        - label: Windows arm64
-          required: false
         - label: Linux amd64
           required: false
         - label: Linux arm64
-          required: false
-        - label: MacOS amd64
           required: false
         - label: MacOS arm64
           required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,8 @@ jobs:
       matrix:
         target:
           - win32-x64
-          - win32-arm64
           - linux-x64
           - linux-arm64
-          - darwin-x64
           - darwin-arm64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Removed x86 on Mac and arm64 on Windows target builds. We don't have pyOCD pyInstaller builds for those yet.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
