### PR TITLE
Temporarily disable commit of automated TPIP report updates

### DIFF
--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -33,6 +33,7 @@ jobs:
         run: yarn run tpip:report
 
       - name: Commit changes
+        if: false
         run: |
           git config --local user.email "git@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Disable commit step for automated TPIP check and generation on `main`. To be re-enabled once we sorted how to deal with CI user and `main` branch protection.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
