### PR TITLE
Run TPIP workflow in PRs for `main`

### DIFF
--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ''
+          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -1,7 +1,7 @@
 name: TPIP
 
 on:
-  push:
+  pull_request:
     paths:
       - '.github/workflows/tpip.yml'
       - docs/third-party-licenses.json

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ''
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -33,6 +33,7 @@ jobs:
         run: yarn run tpip:report
 
       - name: Commit changes
+        if: false
         run: |
           git config --local user.email "git@github.com"
           git config --local user.name "GitHub Action"

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -33,7 +33,6 @@ jobs:
         run: yarn run tpip:report
 
       - name: Commit changes
-        if: false
         run: |
           git config --local user.email "git@github.com"
           git config --local user.name "GitHub Action"

--- a/TPIP.md
+++ b/TPIP.md
@@ -1,6 +1,6 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Report prepared at : 26/02/2025, 16:50:28
+Report prepared at: 03/03/2025, 10:34:00
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Change TPIP workflow to run as part of PRs rather than post commit to `main`. This shall work around the CI user not having (and not supposed to have) direct write access to `main`.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
