### PR TITLE
Add tool mappings to extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,32 @@
     "onStartupFinished"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Arm CMSIS Debugger",
+      "properties": {
+        "toolMapping.GDB": {
+          "type": "object",
+          "markdownDescription": "GDB executable used for `gdb` in launch configurations. Enter the GDB's file path as Value to override default behavior. Add new items to extend the list of mappings.\n * By default, the extension expects the tool to be available through the **Arm Tools Environment Manager** or the `PATH` environment variable.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "arm-none-eabi-gdb": ""
+          }
+        },
+        "toolMapping.GDBServer": {
+          "type": "object",
+          "markdownDescription": "GDB server executable used for `server` in launch configurations. Enter the GDB server's file path as Value to override default behavior. Add new items to extend the list of mappings.\n * `pyocd`: By default invokes pyOCD shipped with this extension.\n * `Other`: By default the extension expects the tool to be available through the **Arm Tools Environment Manager** or the `PATH` environment variable.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "pyocd": "",
+            "JLinkGDBServer": ""
+          }
+        }
+      }
+    },
     "debuggers": [
       {
         "type": "cmsis-debug-pyocd",


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- #37 
- #38 

## Changes
<!-- List the changes this PR introduces -->

- Adds extension settings with the goal to
  - Allow overriding tool executable names with other tools/paths in debug launch configs. Useful if users would like to avoid updating PATH environment variables. And to avoid entering absolute paths in version controlled debug launch configs.
  - Separation of GDB (clients) and GDB servers settings.
  - Allows extending those mappings for portability of other tools (GDBs, GDB servers) not supported out of the box.

Note: This is currently a quick mockup. Functionality not wired in yet.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

New set of extension settings
![image](https://github.com/user-attachments/assets/d525e788-5851-4a76-a6f3-8887006f6040)

Example of updating the GDB client setting on Windows:
![image](https://github.com/user-attachments/assets/b033deb4-fd81-4631-986d-96afcbd9c132)

Example of updating the GDB server settings on Windows:
![image](https://github.com/user-attachments/assets/f8bc6923-0afc-4a89-875b-09ab53e31948)


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
