### PR TITLE
Biring debug console to front on debug session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## Unreleased
+- Implemented [#69](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/69): Bring Debug Console to front during connection.
+
+## 0.0.1
 - Initial release of extension pack on GitHub.
 - Adds pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`.
 - Adds debug configuration providers for debugger type `gdbtarget` to resolve settings for pyOCD and Segger J-Link GDB server connections.

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -53,5 +53,6 @@ module.exports = {
     },
     debug: {
         registerDebugConfigurationProvider: jest.fn(),
+        registerDebugAdapterTrackerFactory: jest.fn(),
     },
 };

--- a/src/debug-configuration/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-configuration/gdbtarget-debug-tracker.test.ts
@@ -19,7 +19,7 @@ import { extensionContextFactory } from '../__test__/vscode.factory';
 
 import * as vscode from 'vscode';
 
-describe('GDBTargetConfigurationProvider', () => {
+describe('GDBTargetDebugTracker', () => {
 
     it('should activate', async () => {
         const debugTracker = new GDBTargetDebugTracker();

--- a/src/debug-configuration/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-configuration/gdbtarget-debug-tracker.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GDBTargetDebugTracker } from './gdbtarget-debug-tracker';
+import { extensionContextFactory } from '../__test__/vscode.factory';
+
+import * as vscode from 'vscode';
+
+describe('GDBTargetConfigurationProvider', () => {
+
+    it('should activate', async () => {
+        const debugTracker = new GDBTargetDebugTracker();
+        const contextMock = extensionContextFactory();
+
+        debugTracker.activate(contextMock);
+
+        expect(contextMock.subscriptions).toHaveLength(1);
+        expect(vscode.debug.registerDebugAdapterTrackerFactory as jest.Mock).toHaveBeenCalledWith('gdbtarget', expect.objectContaining({createDebugAdapterTracker: expect.any(Function)}));
+    });
+
+    it('brings the debug console to front \'onWillStartSession\' is called', async () => {
+        const debugTracker = new GDBTargetDebugTracker();
+
+        debugTracker.onWillStartSession();
+
+        expect(vscode.commands.executeCommand as jest.Mock).toHaveBeenCalledWith('workbench.debug.action.focusRepl');
+    });
+
+});

--- a/src/debug-configuration/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-configuration/gdbtarget-debug-tracker.test.ts
@@ -28,7 +28,7 @@ describe('GDBTargetDebugTracker', () => {
         debugTracker.activate(contextMock);
 
         expect(contextMock.subscriptions).toHaveLength(1);
-        expect(vscode.debug.registerDebugAdapterTrackerFactory as jest.Mock).toHaveBeenCalledWith('gdbtarget', expect.objectContaining({createDebugAdapterTracker: expect.any(Function)}));
+        expect(vscode.debug.registerDebugAdapterTrackerFactory as jest.Mock).toHaveBeenCalledWith('gdbtarget', expect.objectContaining({ createDebugAdapterTracker: expect.any(Function) }));
     });
 
     it('brings the debug console to front \'onWillStartSession\' is called', async () => {

--- a/src/debug-configuration/gdbtarget-debug-tracker.ts
+++ b/src/debug-configuration/gdbtarget-debug-tracker.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2025 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+
+const GDB_TARGET_DEBUGGER_TYPE = 'gdbtarget';
+
+export class GDBTargetDebugTracker implements vscode.DebugAdapterTracker {
+
+    public activate(context: vscode.ExtensionContext) {
+        // Use vscode debug tracker
+        const createDebugAdapterTracker = (_session: vscode.DebugSession): vscode.DebugAdapterTracker => ({
+            onWillStartSession: () => this.onWillStartSession.apply(this)
+        });
+
+        context.subscriptions.push(
+            vscode.debug.registerDebugAdapterTrackerFactory(GDB_TARGET_DEBUGGER_TYPE, { createDebugAdapterTracker })
+        );
+    }
+
+    public onWillStartSession(): void {
+        // Bring debug console to front, let promise float.
+        vscode.commands.executeCommand('workbench.debug.action.focusRepl');
+    }
+
+}

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -15,13 +15,16 @@
  */
 
 import * as vscode from 'vscode';
+import { GDBTargetDebugTracker } from '../debug-configuration/gdbtarget-debug-tracker';
 import { GDBTargetConfigurationProvider } from '../debug-configuration';
 import { logger } from '../logger';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<void> => {
+    const gdbtargetDebugTracker = new GDBTargetDebugTracker();
     const gdbtargetConfigurationProvider = new GDBTargetConfigurationProvider();
 
     // Activate components
+    gdbtargetDebugTracker.activate(context);
     gdbtargetConfigurationProvider.activate(context);
 
     logger.debug('Extension Pack activated');


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- #69 

## Changes
<!-- List the changes this PR introduces -->

- Add simple debug tracker that brings debug console to front when `onWillStartSession` is called.
- Note: Considering as temporary workaround, to request similar behavior from CDT GDB Adapter extension.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
