### PR TITLE
adding pyocd executable to PATH variable

### DIFF
--- a/src/desktop/add-to-path.ts
+++ b/src/desktop/add-to-path.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import * as vscode from 'vscode';
+import { logger } from '../logger';
+import { BuiltinToolPath, isWindows } from './builtin-tool-path';
+
+const PYOCD_BUILTIN_PATH = 'tools/pyocd/pyocd';
+
+export function addPyocdToPath(context: vscode.ExtensionContext): void {
+    //get pyOCD path from tools folder
+    const builtinPyocd = new BuiltinToolPath(PYOCD_BUILTIN_PATH);
+    const pathPyOCD = builtinPyocd.getAbsolutePathDir();
+    if (!pathPyOCD) {
+        logger.debug('pyOCD is not available');
+        return;
+    }
+    //get PATH variable
+    const pathVariable = process.env.PATH;
+    if (!pathVariable) {
+        logger.debug('pyOCD is not available');
+        return;
+    }
+    const delimiter = isWindows ? ';' : ':';
+    const updatePath = pathPyOCD?.concat(delimiter, pathVariable);
+    //add updated path to PATH variable, but only for the terminal inside of vscode
+    context.environmentVariableCollection.replace('PATH', updatePath!);
+}

--- a/src/desktop/add-to-path.ts
+++ b/src/desktop/add-to-path.ts
@@ -36,7 +36,7 @@ export function addPyocdToPath(context: vscode.ExtensionContext): void {
         return;
     }
     const delimiter = isWindows ? ';' : ':';
-    const updatePath = pathPyOCD?.concat(delimiter, pathVariable);
+    const updatePath = pathPyOCD.concat(delimiter, pathVariable);
     //add updated path to PATH variable, but only for the terminal inside of vscode
     context.environmentVariableCollection.replace('PATH', updatePath);
 }

--- a/src/desktop/add-to-path.ts
+++ b/src/desktop/add-to-path.ts
@@ -38,5 +38,5 @@ export function addPyocdToPath(context: vscode.ExtensionContext): void {
     const delimiter = isWindows ? ';' : ':';
     const updatePath = pathPyOCD?.concat(delimiter, pathVariable);
     //add updated path to PATH variable, but only for the terminal inside of vscode
-    context.environmentVariableCollection.replace('PATH', updatePath!);
+    context.environmentVariableCollection.replace('PATH', updatePath);
 }

--- a/src/desktop/builtin-tool-path.ts
+++ b/src/desktop/builtin-tool-path.ts
@@ -19,8 +19,9 @@ import * as fs from 'fs';
 import { EXTENSION_ID } from '../manifest';
 import * as os from 'os';
 import * as vscode from 'vscode';
+import * as path from 'path';
 
-const isWindows = os.platform() === 'win32';
+export const isWindows = os.platform() === 'win32';
 
 export class BuiltinToolPath {
     constructor(protected toolPath: string) {
@@ -32,5 +33,13 @@ export class BuiltinToolPath {
         const absoluteUri = extensionUri?.with({ path: `${extensionUri.path}/${this.toolPath}${isWindows ? '.exe' : ''}` });
         const fsPath = absoluteUri?.fsPath;
         return (fsPath && fs.existsSync(fsPath)) ? absoluteUri : undefined;
+    }
+
+    public getAbsolutePathDir(): string | undefined{
+        const pathToFile = this.getAbsolutePath()?.fsPath;
+        if(pathToFile){
+            return path.dirname(pathToFile);
+        }
+        return undefined;
     }
 }

--- a/src/desktop/builtin-tool-path.ts
+++ b/src/desktop/builtin-tool-path.ts
@@ -37,7 +37,7 @@ export class BuiltinToolPath {
 
     public getAbsolutePathDir(): string | undefined{
         const pathToFile = this.getAbsolutePath()?.fsPath;
-        if(pathToFile){
+        if (pathToFile) {
             return path.dirname(pathToFile);
         }
         return undefined;

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -18,11 +18,13 @@ import * as vscode from 'vscode';
 import { GDBTargetDebugTracker } from '../debug-configuration/gdbtarget-debug-tracker';
 import { GDBTargetConfigurationProvider } from '../debug-configuration';
 import { logger } from '../logger';
+import { addPyocdToPath } from './add-to-path';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<void> => {
     const gdbtargetDebugTracker = new GDBTargetDebugTracker();
     const gdbtargetConfigurationProvider = new GDBTargetConfigurationProvider();
 
+    addPyocdToPath(context);
     // Activate components
     gdbtargetDebugTracker.activate(context);
     gdbtargetConfigurationProvider.activate(context);


### PR DESCRIPTION
## Fixes


- [#83 ](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/83)

## Changes
Created a function to add the executable pyOCD path to the PATH variable of only the vscode terminal


