### PR TITLE
Adding CMSIS_PACK_ROOT handling by default for pyOCD

### DIFF
--- a/src/debug-configuration/gdbtarget-configuration.ts
+++ b/src/debug-configuration/gdbtarget-configuration.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 
 interface EnvironmentConfiguration {
     additionalProperties?: string;
+    cmsisPackRoot?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     default?: any;
 };

--- a/src/debug-configuration/gdbtarget-configuration.ts
+++ b/src/debug-configuration/gdbtarget-configuration.ts
@@ -16,11 +16,8 @@
 
 import * as vscode from 'vscode';
 
-interface EnvironmentConfiguration {
-    additionalProperties?: string;
-    cmsisPackRoot?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    default?: any;
+interface TargetEnvironmentConfiguration {
+    CMSIS_PACK_ROOT?: string;
 };
 
 interface ImageAndSymbolsConfiguration {
@@ -47,8 +44,7 @@ export interface TargetConfiguration {
     host?: string;
     port?: string;
     cwd?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    environment?: any;
+    environment?: TargetEnvironmentConfiguration;
     server?: string;
     serverParameters?: string[];
     serverPortRegExp?: string;
@@ -65,7 +61,8 @@ export interface GDBTargetConfiguration extends vscode.DebugConfiguration {
     program?: string; // required as per 'gdbtarget' debugger contribution, but can be omitted anyway
     gdb?: string;
     cwd?: string;
-    environment?: EnvironmentConfiguration;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    environment?: any;
     gdbAsync?: boolean;
     gdbNonStop?: boolean;
     verbose?: boolean;

--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
@@ -18,6 +18,8 @@ import { logger } from '../../logger';
 import { GDBTargetConfiguration, TargetConfiguration } from '../gdbtarget-configuration';
 import { BuiltinToolPath } from '../../desktop/builtin-tool-path';
 import { BaseConfigurationProvider } from './base-configuration-provider';
+import * as os from 'os';
+import * as path from 'path';
 
 const PYOCD_BUILTIN_PATH = 'tools/pyocd/pyocd';
 const PYOCD_EXECUTABLE_ONLY_REGEXP = /^\s*pyocd(|.exe)\s*$/i;
@@ -63,6 +65,13 @@ export class PyocdConfigurationProvider extends BaseConfigurationProvider {
         const cbuildRunFile = debugConfiguration.cmsis?.cbuildRunFile;
         if (cbuildRunFile && await this.shouldAppendParameter(parameters, PYOCD_CLI_ARG_CBUILDRUN)) {
             parameters.push(PYOCD_CLI_ARG_CBUILDRUN, `${cbuildRunFile}`);
+        }
+        // CMSIS_PACK_ROOT
+        const cmsisPackRoot = debugConfiguration.environment?.cmsisPackRoot;
+        if (!cmsisPackRoot) {
+            os.platform() === 'win32'
+            ? path.join(process.env['LOCALAPPDATA'] ?? os.homedir(), 'arm', 'packs')
+            : path.join(os.homedir(), '.cache', 'arm', 'packs');
         }
         return debugConfiguration;
     }

--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
@@ -42,16 +42,16 @@ export class PyocdConfigurationProvider extends BaseConfigurationProvider {
     }
 
     protected resolveCmsisPackRootPath(target: TargetConfiguration): void {
-        const environmentValue = process.env.CMSIS_PACK_ROOT;
+        const environmentValue = process.env['CMSIS_PACK_ROOT'];
         if (environmentValue) {
             return;
         }
 
-        if(target.environment?.CMSIS_PACK_ROOT) {
+        if (target.environment?.CMSIS_PACK_ROOT) {
             return;
         }
         const cmsisPackRootDefault = os.platform() === 'win32'
-            ? path.join(process.env['LOCALAPPDATA'] ?? os.homedir(), 'arm', 'packs')
+            ? path.join(process.env['LOCALAPPDATA'] ?? os.homedir(), 'Arm', 'Packs')
             : path.join(os.homedir(), '.cache', 'arm', 'packs');
 
         target.environment ??= {};


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#84](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/84)

## Changes
<!-- List the changes this PR introduces -->

- a parameter with the name CMSIS_PACK_ROOT is added to the target.environment configuration for users to add their CMSIS_PACK_ROOT path
- if the user has CMSIS_PACK_ROOT set as a global environment variable, then it will be used instead by pyOCD 


