### PR TITLE
Refine pyOCD path setting for terminals

### DIFF
--- a/src/desktop/add-to-path.ts
+++ b/src/desktop/add-to-path.ts
@@ -29,14 +29,16 @@ export function addPyocdToPath(context: vscode.ExtensionContext): void {
         logger.debug('pyOCD is not available');
         return;
     }
-    //get PATH variable
-    const pathVariable = process.env.PATH;
-    if (!pathVariable) {
-        logger.debug('pyOCD is not available');
+    const delimiter = isWindows ? ';' : ':';
+    const updatePath = `${pathPyOCD}${delimiter}`;
+    //get current environment variable collection
+    const mutator = context.environmentVariableCollection.get('PATH');
+    // Path included and previously used type was 'Prepend'. Change mutator
+    // if other type (we previously used 'Replace' which caused trouble).
+    if (mutator?.type === vscode.EnvironmentVariableMutatorType.Prepend && mutator?.value.includes(updatePath)) {
+        // Nothing to update
         return;
     }
-    const delimiter = isWindows ? ';' : ':';
-    const updatePath = pathPyOCD.concat(delimiter, pathVariable);
     //add updated path to PATH variable, but only for the terminal inside of vscode
-    context.environmentVariableCollection.replace('PATH', updatePath);
+    context.environmentVariableCollection.prepend('PATH', updatePath);
 }


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- #153 

## Changes
<!-- List the changes this PR introduces -->

- Uses `prepend` instead of `replace` env var collection mutator.
- Only updates mutator if path not already set from previous session (cleans up mutators from previous approach).
  - This avoids the terminal to require a refresh on each workspace open.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
