### PR TITLE
changing default launch config initcommands to tbreak instead of break

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
             "gdb": "arm-none-eabi-gdb",
             "initCommands": [
               "load",
-              "break main"
+              "tbreak main"
             ],
             "target": {
               "server": "pyocd",
@@ -83,7 +83,7 @@
               "gdb": "arm-none-eabi-gdb",
               "initCommands": [
                 "load",
-                "break main"
+                "tbreak main"
               ],
               "target": {
                 "server": "pyocd",
@@ -109,7 +109,7 @@
             "gdb": "arm-none-eabi-gdb",
             "initCommands": [
               "load",
-              "break main"
+              "tbreak main"
             ],
             "target": {
               "server": "JLinkGDBServer",
@@ -144,7 +144,7 @@
               "gdb": "arm-none-eabi-gdb",
               "initCommands": [
                 "load",
-                "break main"
+                "tbreak main"
               ],
               "target": {
                 "server": "JLinkGDBServer",


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#155 ](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/155)

## Changes
<!-- List the changes this PR introduces -->

- default launch configuration given in the package.json, initcommands section, tbreak is used instead of break


