### PR TITLE
Add `cmsis`>`cbuildRunFile` setting to J-LINK default configs to configure Peripheral Inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,9 @@
                 "-localhostonly"
               ],
               "port": "3333"
+            },
+            "cmsis": {
+              "cbuildRunFile": "${command:cmsis-csolution.getCbuildRunFile}"
             }
           }
         ],
@@ -163,6 +166,9 @@
                   "-localhostonly"
                 ],
                 "port": "3333"
+              },
+              "cmsis": {
+                "cbuildRunFile": "^\"\\${command:cmsis-csolution.getCbuildRunFile}\""
               }
             }
           }


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- Loosely related to #96 

## Changes
<!-- List the changes this PR introduces -->

- Adds the same `cmsis`>`cbuildRunFile` setting to for J-LINK default configs as for pyOCD. This allows to extract and set the SVD file path for the Peripheral Inspector.
- Note that this doesn't add full `*.cbuild-run.yml` support for Segger J-LINK. Which might be perceived as confusing.

Requires #151 to be merged to show effect.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
