### PR TITLE
Replace broken link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixes [#155](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/155): Go-to-main in `initCommands` of the `launch.json` leaves behind the breakpoint.
 - Partially implements [#96](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/96): Enable Peripheral Inspector.
   - Extracts first SVD file path found in `*.cbuild-run.yml` debug configuration file to automatically set up Peripheral Inspector.
-- Adds initial version of extension [documentation](./docs/index.md).
+- Adds initial version of extension [documentation](https://open-cmsis-pack.github.io/vscode-cmsis-debugger/).
 - Updates included pyOCD distribution
   - Fixes [#133](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/133): Adds default memory map for Cortex-M devices.
   - Improves memory map creation and flash algorithms sorting.


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- Closes #170 

## Changes
<!-- List the changes this PR introduces -->

- Replaces relative path to full docs MD files with new HTML docs link on the web.
- This does not resolve inclusion of HTML docs into extension!

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
