### PR TITLE
Markdown linter and link checker jobs

### DIFF
--- a/.github/markdown-link-check.jsonc
+++ b/.github/markdown-link-check.jsonc
@@ -1,0 +1,10 @@
+{
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
+}

--- a/.github/markdownlint.json
+++ b/.github/markdownlint.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "markdownlint",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+)(:(\\d+))? (MD\\d+\\/[^ ]+) (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 4,
+          "code": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/markdownlint.jsonc
+++ b/.github/markdownlint.jsonc
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120
+  },
+  "MD034": false,
+  "MD041": false
+}

--- a/.github/markdownlint.jsonc
+++ b/.github/markdownlint.jsonc
@@ -4,5 +4,8 @@
     "line_length": 120
   },
   "MD034": false,
-  "MD041": false
+  "MD041": false,
+  "MD007": {
+    "indent": 4
+  }
 }

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,54 @@
+name: Markdown
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/markdown.yml'
+      - '.github/markdownlint.json'
+      - '.github/markdownlint.jsonc'
+      - '**/*.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linter:
+    name: Lint Markdown Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout vscode-cmsis-debugger
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Register Markdownlint Warning Matcher
+        run: echo "::add-matcher::.github/markdownlint.json"
+
+      - name: Lint Markdown Files
+        uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0
+        with:
+          args: '**/*.md'
+          config: '.github/markdownlint.jsonc'
+
+      - name: Remove Markdownlint Warning Matcher
+        if: always()
+        run: echo "::remove-matcher owner=markdownlint::"
+
+  check-links:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check Links
+        uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # master
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          base-branch: ${{ github.base_ref }}
+          config-file: '.github/markdown-link-check.jsonc'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,49 +1,78 @@
 # Change Log
 
 ## 0.1.1
-- Fixes [#153](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/153): PATH variable in terminal sometimes loses modifications from other extensions.
-- Fixes [#155](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/155): Go-to-main in `initCommands` of the `launch.json` leaves behind the breakpoint.
-- Partially implements [#96](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/96): Enable Peripheral Inspector.
-  - Extracts first SVD file path found in `*.cbuild-run.yml` debug configuration file to automatically set up Peripheral Inspector.
+
+- Fixes [#153](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/153): PATH variable in terminal sometimes
+loses modifications from other extensions.
+- Fixes [#155](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/155): Go-to-main in `initCommands` of the
+`launch.json` leaves behind the breakpoint.
+- Partially implements [#96](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/96): Enable Peripheral
+Inspector.
+  - Extracts first SVD file path found in `*.cbuild-run.yml` debug configuration file to automatically set up
+  Peripheral Inspector.
 - Adds initial version of extension [documentation](https://open-cmsis-pack.github.io/vscode-cmsis-debugger/).
 - Updates included pyOCD distribution
-  - Fixes [#133](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/133): Adds default memory map for Cortex-M devices.
+  - Fixes [#133](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/133): Adds default memory map for
+  Cortex-M devices.
   - Improves memory map creation and flash algorithms sorting.
   - Selects current processor core (for example used for flash programming) based on active gdb server connection.
 
 ## 0.1.0
+
 - Updates included pyOCD distribution
-  - Fixes [#92](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/92): `monitor reset halt` command fails for LPCXpresso55S69 if using CMSIS-Pack support in pyOCD.
-  - Fixes [#93](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/93): Download to LPC55S69 flash with GDB and pyOCD ends in errors.
-  - Fixes [#94](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/94): Cannot connect to NXP FRDM-K32L3A6 with pyOCD.
+  - Fixes [#92](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/92): `monitor reset halt` command
+  fails for LPCXpresso55S69 if using CMSIS-Pack support in pyOCD.
+  - Fixes [#93](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/93): Download to LPC55S69 flash with
+  GDB and pyOCD ends in errors.
+  - Fixes [#94](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/94): Cannot connect to
+  NXP FRDM-K32L3A6 with pyOCD.
   - Fixes support for `<memory>` elements from CMSIS PDSC files.
   - Fixes progress bar output during program download.
   - Fixes handling of `__ap` variable in debug sequences.
-  - Improves connection robustness and DP sticky error bits handling for temporary target communication losses and `__errorcontrol` usage (CMSIS debug descriptions). For example in reset scenarios.
+  - Improves connection robustness and DP sticky error bits handling for temporary target communication losses and
+   `__errorcontrol` usage (CMSIS debug descriptions). For example in reset scenarios.
   - Updates CMSIS-DAP probe detection (filters out Cypress KitProg3 bridge).
   - Extends and improves support for `*.cbuild-run.yml` debug configuration files.
 
 ## 0.0.3
-- Fixes [#84](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/84): Cannot use cbuild-run files with pyOCD without CMSIS_PACK_ROOT environment variable.
-- Implements [#83](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/83): Make built-in pyOCD available in VS Code terminals.
-  - Note that there is a known issue with a pyOCD installation in Python virtual environments taking precedence over the built-in pyOCD variant.
+
+- Fixes [#84](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/84): Cannot use cbuild-run files with
+pyOCD without CMSIS_PACK_ROOT environment variable.
+- Implements [#83](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/83): Make built-in pyOCD available
+in VS Code terminals.
+  - Note that there is a known issue with a pyOCD installation in Python virtual environments taking precedence over
+  the built-in pyOCD variant.
 - Updates included pyOCD distribution
-  - Fixes [#91](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/91): "Zephyr kernel detected" warning in shipped pyOCD.
-  - Fixes [#100](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/100): [macOS] - Cannot connect with pyOCD and ULINKplus. Fixes missing `libusb` for macOS.
-  - Fixes [#126](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/126): Flash programming fails on devices where the flash memory's erased value is 0x00. Initializes XPSR register before executing flash algorithm function.
-  - Fixes [#127](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/127): CoreSight root component discovery fails. Fixes how to address APv2.
-  - Fixes [#128](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/128): Programming fails on LPC55S69 when device is erased. Debugger no longer reads back programmed flash memory if `Verify` function is provided by flash algorithm.
-  - Fixes [#131](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/131): AP access failure due to invalid security flags (SPROT).
+  - Fixes [#91](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/91): "Zephyr kernel detected" warning
+  in shipped pyOCD.
+  - Fixes [#100](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/100): [macOS] - Cannot connect with
+  pyOCD and ULINKplus. Fixes missing `libusb` for macOS.
+  - Fixes [#126](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/126): Flash programming fails on
+  devices where the flash memory's erased value is 0x00. Initializes XPSR register before executing flash algorithm
+  function.
+  - Fixes [#127](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/127): CoreSight root component
+  discovery fails. Fixes how to address APv2.
+  - Fixes [#128](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/128): Programming fails on LPC55S69
+   when device is erased. Debugger no longer reads back programmed flash memory if `Verify` function is
+   provided by flash algorithm.
+  - Fixes [#131](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/131):
+   AP access failure due to invalid security flags (SPROT).
   - Extends support for `*.cbuild-run.yml` debug configuration files.
 
 ## 0.0.2
-- Removes [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager) from extension pack. Instead, README lists it as one of the recommended extensions to use with the Arm CMSIS Debugger.
+
+- Removes [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager)
+ from extension pack. Instead, README lists it as one of the recommended extensions to use with the Arm CMSIS Debugger.
 - Fixes use of `${workspace}` to `${workspaceFolder}` in default debug configurations.
-- Reduces and aligns default `initCommands` lists for pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`.
-- Implements [#69](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/69): Bring Debug Console to front during connection.
+- Reduces and aligns default `initCommands` lists for pseudo debugger types `cmsis-debug-pyocd`
+ and `cmsis-debug-jlink`.
+- Implements [#69](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/69): Bring Debug Console to
+ front during connection.
 
 ## 0.0.1
+
 - Initial release of extension pack on GitHub.
 - Adds pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`.
-- Adds debug configuration providers for debugger type `gdbtarget` to resolve settings for pyOCD and Segger J-Link GDB server connections.
+- Adds debug configuration providers for debugger type `gdbtarget` to resolve settings for pyOCD and Segger J-Link
+ GDB server connections.
 - Contributes setting `cmsis`.`cbuildRunFile` to all debugger types (`*` debugger type).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,31 @@ loses modifications from other extensions.
 `launch.json` leaves behind the breakpoint.
 - Partially implements [#96](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/96): Enable Peripheral
 Inspector.
-  - Extracts first SVD file path found in `*.cbuild-run.yml` debug configuration file to automatically set up
+    - Extracts first SVD file path found in `*.cbuild-run.yml` debug configuration file to automatically set up
   Peripheral Inspector.
 - Adds initial version of extension [documentation](https://open-cmsis-pack.github.io/vscode-cmsis-debugger/).
 - Updates included pyOCD distribution
-  - Fixes [#133](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/133): Adds default memory map for
-  Cortex-M devices.
-  - Improves memory map creation and flash algorithms sorting.
-  - Selects current processor core (for example used for flash programming) based on active gdb server connection.
+    - Fixes [#133](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/133): Adds default memory map for
+    Cortex-M devices.
+    - Improves memory map creation and flash algorithms sorting.
+    - Selects current processor core (for example used for flash programming) based on active gdb server connection.
 
 ## 0.1.0
 
 - Updates included pyOCD distribution
-  - Fixes [#92](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/92): `monitor reset halt` command
-  fails for LPCXpresso55S69 if using CMSIS-Pack support in pyOCD.
-  - Fixes [#93](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/93): Download to LPC55S69 flash with
-  GDB and pyOCD ends in errors.
-  - Fixes [#94](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/94): Cannot connect to
-  NXP FRDM-K32L3A6 with pyOCD.
-  - Fixes support for `<memory>` elements from CMSIS PDSC files.
-  - Fixes progress bar output during program download.
-  - Fixes handling of `__ap` variable in debug sequences.
-  - Improves connection robustness and DP sticky error bits handling for temporary target communication losses and
-   `__errorcontrol` usage (CMSIS debug descriptions). For example in reset scenarios.
-  - Updates CMSIS-DAP probe detection (filters out Cypress KitProg3 bridge).
-  - Extends and improves support for `*.cbuild-run.yml` debug configuration files.
+    - Fixes [#92](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/92): `monitor reset halt` command
+    fails for LPCXpresso55S69 if using CMSIS-Pack support in pyOCD.
+    - Fixes [#93](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/93): Download to LPC55S69 flash with
+    GDB and pyOCD ends in errors.
+    - Fixes [#94](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/94): Cannot connect to
+    NXP FRDM-K32L3A6 with pyOCD.
+    - Fixes support for `<memory>` elements from CMSIS PDSC files.
+    - Fixes progress bar output during program download.
+    - Fixes handling of `__ap` variable in debug sequences.
+    - Improves connection robustness and DP sticky error bits handling for temporary target communication losses and
+    `__errorcontrol` usage (CMSIS debug descriptions). For example in reset scenarios.
+    - Updates CMSIS-DAP probe detection (filters out Cypress KitProg3 bridge).
+    - Extends and improves support for `*.cbuild-run.yml` debug configuration files.
 
 ## 0.0.3
 
@@ -40,39 +40,39 @@ Inspector.
 pyOCD without CMSIS_PACK_ROOT environment variable.
 - Implements [#83](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/83): Make built-in pyOCD available
 in VS Code terminals.
-  - Note that there is a known issue with a pyOCD installation in Python virtual environments taking precedence over
-  the built-in pyOCD variant.
+    - Note that there is a known issue with a pyOCD installation in Python virtual environments taking precedence over
+    the built-in pyOCD variant.
 - Updates included pyOCD distribution
-  - Fixes [#91](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/91): "Zephyr kernel detected" warning
-  in shipped pyOCD.
-  - Fixes [#100](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/100): [macOS] - Cannot connect with
-  pyOCD and ULINKplus. Fixes missing `libusb` for macOS.
-  - Fixes [#126](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/126): Flash programming fails on
-  devices where the flash memory's erased value is 0x00. Initializes XPSR register before executing flash algorithm
-  function.
-  - Fixes [#127](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/127): CoreSight root component
-  discovery fails. Fixes how to address APv2.
-  - Fixes [#128](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/128): Programming fails on LPC55S69
-   when device is erased. Debugger no longer reads back programmed flash memory if `Verify` function is
-   provided by flash algorithm.
-  - Fixes [#131](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/131):
-   AP access failure due to invalid security flags (SPROT).
-  - Extends support for `*.cbuild-run.yml` debug configuration files.
+    - Fixes [#91](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/91): "Zephyr kernel detected" warning
+    in shipped pyOCD.
+    - Fixes [#100](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/100): [macOS] - Cannot connect with
+    pyOCD and ULINKplus. Fixes missing `libusb` for macOS.
+    - Fixes [#126](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/126): Flash programming fails on
+    devices where the flash memory's erased value is 0x00. Initializes XPSR register before executing flash algorithm
+    function.
+    - Fixes [#127](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/127): CoreSight root component
+    discovery fails. Fixes how to address APv2.
+    - Fixes [#128](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/128): Programming fails on LPC55S69
+    when device is erased. Debugger no longer reads back programmed flash memory if `Verify` function is
+    provided by flash algorithm.
+    - Fixes [#131](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/131):
+    AP access failure due to invalid security flags (SPROT).
+    - Extends support for `*.cbuild-run.yml` debug configuration files.
 
 ## 0.0.2
 
 - Removes [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager)
- from extension pack. Instead, README lists it as one of the recommended extensions to use with the Arm CMSIS Debugger.
+from extension pack. Instead, README lists it as one of the recommended extensions to use with the Arm CMSIS Debugger.
 - Fixes use of `${workspace}` to `${workspaceFolder}` in default debug configurations.
 - Reduces and aligns default `initCommands` lists for pseudo debugger types `cmsis-debug-pyocd`
- and `cmsis-debug-jlink`.
+and `cmsis-debug-jlink`.
 - Implements [#69](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/69): Bring Debug Console to
- front during connection.
+front during connection.
 
 ## 0.0.1
 
 - Initial release of extension pack on GitHub.
 - Adds pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`.
 - Adds debug configuration providers for debugger type `gdbtarget` to resolve settings for pyOCD and Segger J-Link
- GDB server connections.
+GDB server connections.
 - Contributes setting `cmsis`.`cbuildRunFile` to all debugger types (`*` debugger type).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 - Install **Visual Studio Code®**.
 - Install **Node.js®** on your machine and ensure it is on your path.
-  - The currently recommended version is 20.x (LTS).
+    - The currently recommended version is 20.x (LTS).
 - Install **Yarn** which is used to build and execute scripts in this repository:
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ supports the MI protocol.
 - [Memory Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector), an Eclipse
 CDT.cloud extension that provides a powerful and configurable memory viewer that works with debug adapters.
 
-- [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector), an EclipseCDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
+- [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector), an
+EclipseCDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
 
 ## Recommended Extensions
 
@@ -107,7 +108,7 @@ the following gaps during debug launch:
 - Extends the `target`>`serverParameters` list of `pyocd` command line arguments:
   - Prepends `gdbserver` if not present.
   - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets
-	that port setting's value.
+  that port setting's value.
   - Appends `--cbuild-run` and the corresponding `cbuildRunFile` path if `cmsis`>`cbuildRunFile` is set.
 
 **Note**: The built-in version of pyOCD supports the command line option `--cbuild-run` which isn't available

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ the following gaps during debug launch:
 - If option `target`>`server` is set to `pyocd`, then it expands to the absolute path of
  the built-in pyOCD distribution.
 - Extends the `target`>`serverParameters` list of `pyocd` command line arguments:
-  - Prepends `gdbserver` if not present.
-  - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets
-  that port setting's value.
-  - Appends `--cbuild-run` and the corresponding `cbuildRunFile` path if `cmsis`>`cbuildRunFile` is set.
+    - Prepends `gdbserver` if not present.
+    - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets
+    that port setting's value.
+    - Appends `--cbuild-run` and the corresponding `cbuildRunFile` path if `cmsis`>`cbuildRunFile` is set.
 
 **Note**: The built-in version of pyOCD supports the command line option `--cbuild-run` which isn't available
 in releases outside this extension.
@@ -131,8 +131,8 @@ Additionally, the extension contributes a debug configuration resolver which aut
 gaps during debug launch:
 
 - Extends the `target`>`serverParameters` list of `JLinkGDBServer`/`JLinkGDBServerCL` command line arguments:
-  - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets that port
-  setting's value.
+    - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets that
+    port setting's value.
 
 ## Known Limitations and Workarounds
 

--- a/README.md
+++ b/README.md
@@ -3,165 +3,238 @@
 
 # Arm CMSIS Debugger
 
-The Arm® CMSIS Debugger extension is an extension pack for Visual Studio Code® that demonstrates how to combine technologies from various open source projects to create a comprehensive debug platform for Arm-based IoT solutions.
+The Arm® CMSIS Debugger extension is an extension pack for Visual Studio Code® that demonstrates
+how to combine technologies from various open source projects to create a comprehensive debug platform for
+Arm-based IoT solutions.
 
 Related open source projects are
 
 - [Open-CMSIS-Pack](https://www.open-cmsis-pack.org/) of which this extension is part of.
-- [Eclipse® CDT.cloud™](https://eclipse.dev/cdt-cloud/), an open-source project that hosts a number of components and best practices for building customizable web-based C/C++ tools.
-- [pyOCD](https://pyocd.io/), a Python based tool and API for debugging, programming, and exploring Arm Cortex® microcontrollers.
+- [Eclipse® CDT.cloud™](https://eclipse.dev/cdt-cloud/), an open-source project that hosts
+a number of components and best practices for building customizable web-based C/C++ tools.
+- [pyOCD](https://pyocd.io/), a Python based tool and API for debugging, programming,
+and exploring Arm Cortex® microcontrollers.
 - [GDB](https://www.sourceware.org/gdb/), the debugger of the GNU Project.
 
 ## The Arm CMSIS Debugger Extension Pack
 
-The Arm CMSIS Debugger extension is an [extension pack](https://code.visualstudio.com/api/references/extension-manifest#extension-packs). It allows to install multiple separate extensions together.
+The Arm CMSIS Debugger extension is an [extension pack](https://code.visualstudio.com/api/references/extension-manifest#extension-packs).
+It allows to install multiple separate extensions together.
 
 ## Included Extensions
 
 The following extensions are included in this extension pack:
 
+<<<<<<< HEAD
 - [CDT™ GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode), an Eclipse CDT.cloud extension that supports debugging using GDB and any other debuggers that supports the MI protocol.
 
 - [Memory Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector), an Eclipse CDT.cloud extension that provides a powerful and configurable memory viewer that works with debug adapters.
 
 - [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector), an Eclipse CDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
+=======
+- [CDT™ GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode),
+an Eclipse CDT.cloud extension that supports debugging using GDB and any other debuggers that supports the MI protocol.
+- [Memory Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector), an Eclipse
+CDT.cloud extension that provides a powerful and configurable memory viewer that works with debug adapters.
+- [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector),
+an Eclipse CDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
+>>>>>>> cb1e6f0 (Markdown linter and link checker jobs)
 
 ## Recommended Extensions
 
 We recommend to install the following extensions to simplify the user experience:
 
+<<<<<<< HEAD
 - [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager), an extension that allows you to download, install, and manage software development tools using [Microsoft® Vcpkg](https://vcpkg.io/en/index.html) artifacts. For example, use this extension to install the [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) which comes with a GDB variant for Arm CPUs.
 
 - [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution), an extension that is a graphical user interface for csolution projects that use the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/). Use this extension to build your csolution projects, to generate `*.cbuild-run.yml` debug configuration files, and to make use of contributed commands in your debug launch configurations.
+=======
+- [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager), an
+extension that allows to download, install, and manage software development tools using
+[Microsoft® Vcpkg](https://vcpkg.io/en/index.html) artifacts. Use this extension to for example install the
+`GCC compiler for ARM CPUs` which comes with a GDB variant for Arm CPUs.
+- [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution), an extension that
+is a graphical user interface for csolution projects that use the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/).
+Use this extension to build your csolution projects, to generate `*.cbuild-run.yml` debug configuration files,
+and to make use of contributed commands in your debug launch configurations.
+>>>>>>> cb1e6f0 (Markdown linter and link checker jobs)
 
 ## Debug Setup
 
-The debug setup requires a GDB installation supporting the GDB remote protocol and that can connect to a GDB server like pyOCD.
+The debug setup requires a GDB installation supporting the GDB remote protocol and that can connect to a
+GDB server like pyOCD.
 
-We recommend to install the [`Arm GNU Toolchain`](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) using the `Arm Tools Environment Manager` extension. It comes with `arm-none-eabi-gdb` which is used in the Arm CMSIS Debugger default debug configurations.
+We recommend to install the [`Arm GNU Toolchain`](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain)
+using the `Arm Tools Environment Manager` extension. It comes with `arm-none-eabi-gdb` which is used in the
+Arm CMSIS Debugger default debug configurations.
 
 ### pyOCD Debug Setup
 
 This extension includes a pyOCD distribution which is used by default.
 
-If you wish to use a different pyOCD installation, enter the full path to the executable (including the file name) in the `target`>`server` setting.
+If you wish to use a different pyOCD installation, enter the full path to the executable (including the file name)
+in the `target`>`server` setting.
 
 ### SEGGER® J-LINK® Debug Setup
 
-Install the latest [J-LINK Software and Documentation Pack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) from [SEGGER](https://www.segger.com/). Ensure all required drivers and host platform specific settings are done.
+Install the latest [J-LINK Software and Documentation Pack](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
+from [SEGGER](https://www.segger.com/). Ensure all required drivers and host platform specific settings are done.
 
-The extension expects the installation folder to be on your system `PATH` environment variable. Alternatively, update your debug configuration's `target`>`server` setting to contain the full path to the J-LINK GDB server executable (including the file name).
+The extension expects the installation folder to be on your system `PATH` environment variable. Alternatively, update
+your debug configuration's `target`>`server` setting to contain the full path to the J-LINK GDB server executable
+(including the file name).
 
 ## Extension Functionality
 
 This extension contributes additional functionality to work seamlessly with other extensions.
 
-- The pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`. These types allow a more seamless integration into your IDE. However, these are not full debug adapters but generate debug configurations of type `gdbtarget` which comes with the [CDT GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode).
-- A [debug configuration provider](https://code.visualstudio.com/api/references/vscode-api#DebugConfigurationProvider) for the type `gdbtarget` which comes with the [CDT GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode). This provider automatically fills in default values for known remote GDB servers when launching a debug session.
-- CMSIS specific launch configuration items for the `*` debugger type, i.e. visible for all debugger types. It depends on the actually used debug adapter type if this information is known and utilized.
+- The pseudo debugger types `cmsis-debug-pyocd` and `cmsis-debug-jlink`. These types allow a more seamless
+integration into your IDE. However, these are not full debug adapters but generate debug configurations of
+type `gdbtarget` which comes with the [CDT GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode).
+- A [debug configuration provider](https://code.visualstudio.com/api/references/vscode-api#DebugConfigurationProvider)
+for the type `gdbtarget` which comes with the [CDT GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode).
+This provider automatically fills in default values for known remote GDB servers when launching a debug session.
+- CMSIS specific launch configuration items for the `*` debugger type, i.e. visible for all debugger types.
+It depends on the actually used debug adapter type if this information is known and utilized.
 
 ### Pseudo Debugger Types
 
-This section describes the contributed pseudo debugger types and their support through the contributed debug configuration provider for type `gdbtarget`.
+This section describes the contributed pseudo debugger types and their support through the contributed debug
+configuration provider for type `gdbtarget`.
 
 #### CMSIS Debugger (pyOCD) - `cmsis-debug-pyocd`
 
-The `cmsis-debug-pyocd` debugger type is used to add a debug configuration in the `launch.json` file for debugging with GDB and pyOCD.<br>
+The `cmsis-debug-pyocd` debugger type is used to add a debug configuration in the
+`launch.json` file for debugging with GDB and pyOCD.  
 This configuration uses the `gdbtarget` debugger type registered by the CDT GDB Debug Adapter Extension.
 
-Additionaly, the extension contributes a debug configuration resolver which automatically fills the following gaps during debug launch:
+Additionally, the extension contributes a debug configuration resolver which automatically fills
+the following gaps during debug launch:
 
-- If option `target`>`server` is set to `pyocd`, then it expands to the absolute path of the built-in pyOCD distribution.
+- If option `target`>`server` is set to `pyocd`, then it expands to the absolute path of
+ the built-in pyOCD distribution.
 - Extends the `target`>`serverParameters` list of `pyocd` command line arguments:
     - Prepends `gdbserver` if not present.
-    - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets that port setting's value.
+    - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets
+	that port setting's value.
     - Appends `--cbuild-run` and the corresponding `cbuildRunFile` path if `cmsis`>`cbuildRunFile` is set.
 
-**Note**: The built-in version of pyOCD supports the command line option `--cbuild-run` which isn't available in releases outside this extension.
+**Note**: The built-in version of pyOCD supports the command line option `--cbuild-run` which isn't available
+in releases outside this extension.
 
 #### CMSIS Debugger (J-LINK) - `cmsis-debug-jlink`
 
-The `cmsis-debug-jlink` debugger type is used to add a debug configuration in the launch.json file for debug with GDB and the SEGGER J-LINK GDB server.<br>
+The `cmsis-debug-jlink` debugger type is used to add a debug configuration in the launch.json file for debug
+with GDB and the SEGGER J-LINK GDB server.  
 This configuration uses the `gdbtarget` debugger type registered by the CDT GDB Debug Adapter Extension.
 
-**Note**: The generated default debug configuration uses the value `JLinkGDBServer` as `target`>`server` setting. This executable has differing behavior on supported host platform:
+**Note**: The generated default debug configuration uses the value `JLinkGDBServer` as `target`>`server` setting.
+This executable has differing behavior on supported host platform:
 
 - Linux and macOS: A GUI-less version of the GDB server is launched.
-- Windows®: A GDB server with GUI is launched. Update `target`>`server` to `JLinkGDBServerCL` to launch a GUI-less version on Windows, too.
+- Windows®: A GDB server with GUI is launched. Update `target`>`server` to `JLinkGDBServerCL` to launch a
+ GUI-less version on Windows, too.
 
-Additionaly, the extension contributes a debug configuration resolver which automatically fills the following gaps during debug launch:
+Additionally, the extension contributes a debug configuration resolver which automatically fills the following
+gaps during debug launch:
 
 - Extends the `target`>`serverParameters` list of `JLinkGDBServer`/`JLinkGDBServerCL` command line arguments:
-    - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets that port setting's value.
+  - Appends `--port <gdbserver_port>` if the `target`>`port` setting is set, where `<gdbserver_port>` gets that port
+  setting's value.
 
 ## Known Limitations and Workarounds
 
 ### pyOCD fails to load `*.cbuild-run.yml` in the default configuration
 
-When I use the default debug configuration for pyOCD, I get errors that pyOCD cannot find the solutions `*.cbuild-run.yml` file.
+When I use the default debug configuration for pyOCD, I get errors that pyOCD cannot find the solutions
+`*.cbuild-run.yml` file.
 
 **Possible Reasons**:
 
-1. The application's CMSIS solution was initially built with a CMSIS-Toolbox version prior to v2.8.0 which is the first version to generate `*.cbuild-run.yml` files.
-1. You are using an [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension prior to v1.52.0 which is the first version to fully support the `${command:cmsis-csolution.getCbuildRunFile}` command.
+1. The application's CMSIS solution was initially built with a CMSIS-Toolbox version prior to v2.8.0 which is
+the first version to generate `*.cbuild-run.yml` files.
+1. You are using an [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension
+prior to v1.52.0 which is the first version to fully support the `${command:cmsis-csolution.getCbuildRunFile}` command.
 
 **Workarounds/Solutions**:
 
-1. Update the CMSIS-Toolbox to the latest version. Additionally, you may have to run `cbuild setup --update-rte` in a terminal for a first-time generation of `*.cbuild-run.yml` file in an existing workspace.
-1. Update to Arm CMSIS Solution extension v1.52.0. Alternatively, replace `${command:cmsis-csolution.getCbuildRunFile}` with the path to the `*.cbuild-run.yml` in your workspace (`cmsis`>`cbuildRunFile` debug configuration setting).
+1. Update the CMSIS-Toolbox to the latest version. Additionally, you may have to run `cbuild setup --update-rte`
+in a terminal for a first-time generation of `*.cbuild-run.yml` file in an existing workspace.
+1. Update to Arm CMSIS Solution extension v1.52.0. Alternatively, replace
+`${command:cmsis-csolution.getCbuildRunFile}` with the path to the `*.cbuild-run.yml` in your workspace
+(`cmsis`>`cbuildRunFile` debug configuration setting).
 
 ### AXF files built with Arm Compiler 6 toolchain
 
-When I download an AXF file built with Arm Compiler 6, I see the following warning and my application does not execute correctly. This happens regardless of the selected GDB server.
-```
+When I download an AXF file built with Arm Compiler 6, I see the following warning and my application
+does not execute correctly. This happens regardless of the selected GDB server.
+
+```txt
 warning: Loadable section "RW_RAM0" outside of ELF segments
   in /path/to/my/application.axf
 ```
 
-**Possible Reason**: `arm-none-eabi-gdb` does not correctly load ELF program segments due to the way that Arm Compiler 6 generates section and program header information when scatterloading is used.
+**Possible Reason**: `arm-none-eabi-gdb` does not correctly load ELF program segments due to the way that
+Arm Compiler 6 generates section and program header information when scatterloading is used.
 
-**Workaround**: You can generate a HEX file for the program download, and the ELF file for debug purposes only. The following steps are required if you build a [CSolution](https://open-cmsis-pack.github.io/cmsis-toolbox/build-overview/)-based application with the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/):
+**Workaround**: You can generate a HEX file for the program download, and the ELF file for debug purposes only.
+The following steps are required if you build a [CSolution](https://open-cmsis-pack.github.io/cmsis-toolbox/build-overview/)-based
+application with the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/):
 
 1. Edit the `*.cproject.yml` file(s) of your application.
-1. Modify the [`output:type:`](https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#output) node to generate both an `elf` and a `hex` file:
-```
+1. Modify the [`output:type:`](https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#output) node
+to generate both an `elf` and a `hex` file:
+
+```yml
   output:
     type:
       - elf
       - hex  
 ```
+
 1. Build the solution.
 1. Keep the default configuration's `program` setting as is.
-```
+
+```txt
 "program": "${command:cmsis-csolution.getBinaryFile}",
 ```
-1. Modify the default debug configuration's `initCommands` list, so that the `load` command gets the relative path to the generated HEX file.
-```
-            "initCommands": [
-                "load ./relative/path/to/my/application.hex",
-                "break main"
-            ],
+
+1. Modify the default debug configuration's `initCommands` list, so that the `load` command gets the relative
+path to the generated HEX file.
+
+```json
+"initCommands": [
+    "load ./relative/path/to/my/application.hex",
+    "break main"
+],
 ```
 
-This instructs the debugger to load the debug information from the ELF file and to use the HEX file for program download.
+This instructs the debugger to load the debug information from the ELF file and to use the HEX file
+for program download.
 
 ### `arm-none-eabi-gdb` requires DWARF5 debug information
 
-`arm-none-eabi-gdb` generates the following warnings when I debug ELF files with [DWARF](https://dwarfstd.org/) debug information of standard version 4 and earlier. And the debug illusion seems to be broken in many places.<br>
-```
+`arm-none-eabi-gdb` generates the following warnings when I debug ELF files with [DWARF](https://dwarfstd.org/) debug
+information of standard version 4 and earlier. And the debug illusion seems to be broken in many places.  
+
+```txt
 warning: (Internal error: pc 0x8006a18 in read in CU, but not in symtab.)
 ```
 
 **Possible Reason**: `arm-none-eabi-gdb` works best with DWARF debug information of standard version 5.
 
-**Solution**: Make sure to build your application ELF file with DWARF version 5 debug information. Please refer to your toolchain's user reference manual. This may require updates to all build tools like compiler and assembler. For example use `-gdwarf-5` for `armclang`.
+**Solution**: Make sure to build your application ELF file with DWARF version 5 debug information. Please refer to
+your toolchain's user reference manual. This may require updates to all build tools like compiler and assembler.
+For example use `-gdwarf-5` for `armclang`.
 
 ## Trademarks
 
-Arm and Cortex are registered trademarks of Arm Limited (or its subsidiaries or affiliates) in the US and/or elsewhere.<br>
-Windows, Visual Studio Code, VS Code, and the Visual Studio Code icon are trademarks of Microsoft Corporation. All rights reserved.<br>
-Mac and macOS are trademarks of Apple Inc., registered in the U.S. and other countries and regions.<br>
-Eclipse, CDT, and CDT.cloud are trademarks of Eclipse Foundation, Inc.<br>
-SEGGER and J-LINK are registered trademarks of SEGGER Microcontroller GmbH.<br>
-Node.js is a registered trademark of the OpenJS Foundation.<br>
-GDB and GCC are part of the GNU Project and are maintained by the Free Software Foundation.<br>
+Arm and Cortex are registered trademarks of Arm Limited (or its subsidiaries or affiliates)
+in the US and/or elsewhere.  
+Windows, Visual Studio Code, VS Code, and the Visual Studio Code icon are trademarks of Microsoft Corporation.
+All rights reserved.  
+Mac and macOS are trademarks of Apple Inc., registered in the U.S. and other countries and regions.  
+Eclipse, CDT, and CDT.cloud are trademarks of Eclipse Foundation, Inc.  
+SEGGER and J-LINK are registered trademarks of SEGGER Microcontroller GmbH.  
+Node.js is a registered trademark of the OpenJS Foundation.  
+GDB and GCC are part of the GNU Project and are maintained by the Free Software Foundation.  

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,17 +10,22 @@ This document outlines the security procedures and policies for the Open-CMSIS-P
 
 ## Reporting a Security Issue  
 
-The Open-CMSIS-Pack vscode-cmsis-debugger maintainers take security issues seriously and appreciate responsible disclosure. Your efforts to improve project security are highly valued.  
+The Open-CMSIS-Pack vscode-cmsis-debugger maintainers take security issues seriously and appreciate responsible
+disclosure. Your efforts to improve project security are highly valued.  
 
-We use GitHub's [private vulnerability reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) guidelines.
-To report a security issue, please click on [Report a vulnerability](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/advisories/new) and include:  
+We use GitHub's [private vulnerability reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+guidelines.
+To report a security issue, please click on
+[Report a vulnerability](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/advisories/new) and
+include:  
 
 - A detailed description of the issue  
 - Steps to reproduce the vulnerability  
 - Affected project versions  
 - Any known mitigations  
 
-A maintainer will acknowledge your report as soon as possible and guide the next steps. We will keep you informed of progress toward a fix and may request additional details if needed.  
+A maintainer will acknowledge your report as soon as possible and guide the next steps. We will keep you informed of
+progress toward a fix and may request additional details if needed.  
 
 ## Vulnerability Management  
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -64,6 +64,7 @@ For debugging with pyOCD, the following is added to the `launch.json` file:
 
 For a single-core device, you need to add the relative path to the HEX file to `"initCommands"` - `"load"`.
 
+<!-- markdownlint-disable-next-line MD036 -->
 **Example**
 
 ```yml
@@ -102,6 +103,7 @@ For a multi-core device, you need to:
 
 - add for each core the relative path to the AXF (ELF) files for each core to `"program"`.
 
+<!-- markdownlint-disable-next-line MD036 -->
 **Example**
 
 ```yml
@@ -153,8 +155,8 @@ For a multi-core device, you need to:
 
 ## Debugging with J-Link
 
-For debugging with Segger J-Link (using the [J-Link GDB Server](https://kb.segger.com/J-Link_GDB_Server)), the following is
-added to the `launch.json` file:
+For debugging with Segger J-Link (using the [J-Link GDB Server](https://kb.segger.com/J-Link_GDB_Server)), the following
+is added to the `launch.json` file:
 
 ```yml
 {
@@ -208,6 +210,7 @@ For a multi-core device, you need to:
 
 - add the XML file to the `"serverParameters"` so that the Segger GDB server can pick them up.
 
+<!-- markdownlint-disable-next-line MD036 -->
 **Example**
 
 ```yml
@@ -253,6 +256,7 @@ For a multi-core device, you need to:
 
 For this example, the content of the `JLinkDevices.xml` file is as follows:
 
+<!-- markdownlint-disable MD013 -->
 ```xml
 <DataBase>
   <Device>
@@ -263,3 +267,4 @@ For this example, the content of the `JLinkDevices.xml` file is as follows:
   </Device>
 </DataBase>
 ```
+<!-- markdownlint-enable MD013 -->

--- a/docs/debug_views.md
+++ b/docs/debug_views.md
@@ -133,9 +133,9 @@ To add a conditional breakpoint:
 
 - Create a conditional breakpoint
 
-  - Right-click in the editor margin and select Add Conditional Breakpoint.
+    - Right-click in the editor margin and select Add Conditional Breakpoint.
 
-  - Use the Add Conditional Breakpoint command in the Command Palette (⇧⌘P).
+    - Use the Add Conditional Breakpoint command in the Command Palette (⇧⌘P).
 
 - Choose the type of condition you want to set (expression, hit count, or wait for breakpoint).
 
@@ -145,10 +145,10 @@ To add a condition to an existing breakpoint:
 
 - Edit an existing breakpoint
 
-  - Right-click on the breakpoint in the editor margin and select Edit Breakpoint.
+    - Right-click on the breakpoint in the editor margin and select Edit Breakpoint.
 
-  - Select the pencil icon next for an existing breakpoint in the **BREAKPOINTS section** of
-  the **Run and Debug view**.
+    - Select the pencil icon next for an existing breakpoint in the **BREAKPOINTS section** of
+    the **Run and Debug view**.
 
 - Edit the condition (expression, hit count, or wait for breakpoint).
 

--- a/docs/debug_views.md
+++ b/docs/debug_views.md
@@ -31,13 +31,15 @@ following aspects:
 
 ## Debug toolbar
 
-Once a debug session starts, the **Debug toolbar** appears at the top of the window. The toolbar contains actions to control
-the flow of the debug session, such as stepping through code, pausing execution, and stopping the debug session.
+Once a debug session starts, the **Debug toolbar** appears at the top of the window. The toolbar contains actions to
+control the flow of the debug session, such as stepping through code, pausing execution, and stopping the debug
+session.
 
 ![Debug toolbar](./images/debug-toolbar.png)
 
 The following table describes the actions available in the debug toolbar:
 
+<!-- markdownlint-disable MD013 MD033 -->
 | Action | Description |
 |--------|-------------|
 | Continue/Pause (F5) | **Continue**: Resume normal program/script execution (up to the next breakpoint).<br>**Pause**: Inspect code executing at the current line and debug line-by-line. |
@@ -46,21 +48,21 @@ The following table describes the actions available in the debug toolbar:
 | Step Out (Shift + F11) | When inside a method or subroutine, return to the earlier execution context by completing remaining lines of the current method as though it were a single command. |
 | Restart (Shift + Ctrl/Cmd + F5) | Terminate the current program execution and start debugging again using the current run configuration. |
 | Stop (Shift + F5) | Terminate the current program execution. |
-
-If your debugging sessions involve multiple targets (for example, a multi-core device), the debug toolbar shows the list
-of sessions and lets you switch between them.
+<!-- markdownlint-enable MD013 MD033 -->
+If your debugging sessions involve multiple targets (for example, a multi-core device), the debug toolbar shows the
+list of sessions and lets you switch between them.
 
 ## VARIABLES section
 
 During a debugging session, you can inspect variables, expressions, and registers in the **VARIABLES section** of the
 **Run and Debug view** or by hovering over their source in the editor. Variable values and expression evaluation are
-relative to the selected stack frame in the **CALL STACK section**. In case of multi-core, registers are relative to the
-core that you are debugging.
+relative to the selected stack frame in the **CALL STACK section**. In case of multi-core, registers are relative to
+the core that you are debugging.
 
 ![VARIABLES section](./images/VARIABLES-section.png)
 
-To change the value of a variable during the debugging session, right-click on the variable in the **VARIABLES section** and
-select **Set Value**.
+To change the value of a variable during the debugging session, right-click on the variable in the
+**VARIABLES section** and select **Set Value**.
 
 You can use the **Copy Value action** to copy the variable's value, or the **Copy as Expression action** to copy an
 iexpression to access the variable. You can then use this expression in the [**WATCH section**](#watch-section).
@@ -78,8 +80,8 @@ Variables and expressions can also be evaluated and watched in the Run and Debug
 
 ## CALL STACK section
 
-The **CALL STACK** sections shows objects that are currently on stack. Threads are shown for applications that use an RTOS.
-Each object is associated to its location or value, and type.
+The **CALL STACK** sections shows objects that are currently on stack. Threads are shown for applications
+that use an RTOS. Each object is associated to its location or value, and type.
 
 ![CALL STACK section](./images/call-stack-section.png)
 
@@ -93,8 +95,8 @@ The context menu allows to:
 
 ## BREAKPOINTS section
 
-A breakpoint pauses the execution of your code at a specific point, so you can inspect the state of your application at that
-point. VS Code supports several types of breakpoints.
+A breakpoint pauses the execution of your code at a specific point, so you can inspect the state of your
+application at that point. VS Code supports several types of breakpoints.
 
 ### Setting breakpoints
 
@@ -104,8 +106,8 @@ To set or unset a breakpoint, click on the editor margin or use **F9** on the cu
 
 - Disabled breakpoints have a filled gray circle.
 
-- When a debugging session starts, breakpoints that can't be registered with the debugger change to a gray hollow circle.
-  The same might happen if the source is edited while a debug session without live-edit support is running.
+- When a debugging session starts, breakpoints that can't be registered with the debugger change to a gray hollow
+circle. The same might happen if the source is edited while a debug session without live-edit support is running.
 
 ![Breakpoint in the edirot margin](./images/bkpt-in-editor-margin.png)
 
@@ -118,7 +120,8 @@ breakpoints in your code and provides extra actions to manage them.
 
 #### Conditional breakpoints
 
-A powerful VS Code debugging feature is the ability to set conditions based on expressions, hit counts, or a combination of both.
+A powerful VS Code debugging feature is the ability to set conditions based on expressions, hit counts,
+or a combination of both.
 
 - Expression condition: The breakpoint is hit whenever the expression evaluates to true.
 
@@ -130,9 +133,9 @@ To add a conditional breakpoint:
 
 - Create a conditional breakpoint
 
-    - Right-click in the editor margin and select Add Conditional Breakpoint.
+  - Right-click in the editor margin and select Add Conditional Breakpoint.
 
-    - Use the Add Conditional Breakpoint command in the Command Palette (⇧⌘P).
+  - Use the Add Conditional Breakpoint command in the Command Palette (⇧⌘P).
 
 - Choose the type of condition you want to set (expression, hit count, or wait for breakpoint).
 
@@ -142,61 +145,63 @@ To add a condition to an existing breakpoint:
 
 - Edit an existing breakpoint
 
-    - Right-click on the breakpoint in the editor margin and select Edit Breakpoint.
+  - Right-click on the breakpoint in the editor margin and select Edit Breakpoint.
 
-    - Select the pencil icon next for an existing breakpoint in the **BREAKPOINTS section** of the **Run and Debug view**.
+  - Select the pencil icon next for an existing breakpoint in the **BREAKPOINTS section** of
+  the **Run and Debug view**.
 
 - Edit the condition (expression, hit count, or wait for breakpoint).
 
 #### Triggered breakpoints
 
-A triggered breakpoint is type of conditional breakpoint that is enabled once another breakpoint is hit. They can be useful
-when diagnosing failure cases in code that happen only after a certain precondition.
+A triggered breakpoint is type of conditional breakpoint that is enabled once another breakpoint is hit. They can
+be useful when diagnosing failure cases in code that happen only after a certain precondition.
 
-Triggered breakpoints can be set by right-clicking on the glyph margin, selecting **Add Triggered Breakpoint**, and then
-choosing which other breakpoint enables the breakpoint.
+Triggered breakpoints can be set by right-clicking on the glyph margin, selecting **Add Triggered Breakpoint**, and
+then choosing which other breakpoint enables the breakpoint.
 
 ![Creating a triggered breakpoint](./images/triggered-bkpt.gif)
 
 #### Inline breakpoints
 
-Inline breakpoints are only hit when the execution reaches the column associated with the inline breakpoint. This is useful
-when debugging minified code, which contains multiple statements in a single line.
+Inline breakpoints are only hit when the execution reaches the column associated with the inline breakpoint.
+This is useful when debugging minified code, which contains multiple statements in a single line.
 
-An inline breakpoint can be set using **Shift + F9** or through the context menu during a debug session. Inline breakpoint
- are shown inline in the editor.
+An inline breakpoint can be set using **Shift + F9** or through the context menu during a debug session.
+Inline breakpoint are shown inline in the editor.
 
-Inline breakpoints can also have conditions. Editing multiple breakpoints on a line is possible through the context menu in
-the editor's left margin.
+Inline breakpoints can also have conditions. Editing multiple breakpoints on a line is possible through the
+context menu in the editor's left margin.
 
 #### Function breakpoints
 
-Instead of placing breakpoints directly in source code, a debugger can support creating breakpoints by specifying a function
-name. This is useful in situations where source is not available but a function name is known.
+Instead of placing breakpoints directly in source code, a debugger can support creating breakpoints by specifying
+a function name. This is useful in situations where source is not available but a function name is known.
 
-To create a function breakpoint, select the + button in the **BREAKPOINTS section** header and enter the function name. Function
-breakpoints are shown with a red triangle in the **BREAKPOINTS section**.
+To create a function breakpoint, select the + button in the **BREAKPOINTS section** header and enter the function
+name. Function breakpoints are shown with a red triangle in the **BREAKPOINTS section**.
 
 #### Data breakpoints
 
-If a debugger supports data breakpoints, they can be set from the context menu in the **VARIABLES section**. The Break on
-Value Change/Read/Access commands add a data breakpoint that is hit when the value of the underlying variable changes/is
-read/is accessed. Data breakpoints are shown with a red hexagon in the **BREAKPOINTS section**.
+If a debugger supports data breakpoints, they can be set from the context menu in the **VARIABLES section**. The Break
+on Value Change/Read/Access commands add a data breakpoint that is hit when the value of the underlying variable
+changes/is read/is accessed. Data breakpoints are shown with a red hexagon in the **BREAKPOINTS section**.
 
 #### Logpoints
 
-A logpoint is a variant of a breakpoint that does not interrupt into the debugger, but instead logs a message to the debug
-console. Logpoints can help you save time by not having to add or remove logging statements in your code.
+A logpoint is a variant of a breakpoint that does not interrupt into the debugger, but instead logs a message to the
+debug console. Logpoints can help you save time by not having to add or remove logging statements in your code.
 
 A logpoint is represented by a diamond-shaped icon. Log messages are plain text but can also include expressions to be
 evaluated within curly braces ('{}').
 
-To add a logpoint, right-click in the editor left margin and select Add Logpoint, or use the **Debug: Add Logpoint...**
-command in the Command Palette (**Ctrl/Cmd + Shift + p**).
+To add a logpoint, right-click in the editor left margin and select Add Logpoint, or use the
+**Debug: Add Logpoint...** command in the Command Palette (**Ctrl/Cmd + Shift + p**).
 
 ![Creating a logpoint](./images/create-logpoint.gif)
 
-Just like regular breakpoints, logpoints can be enabled or disabled and can also be controlled by a condition and/or hit count.
+Just like regular breakpoints, logpoints can be enabled or disabled and can also be controlled by a condition
+and/or hit count.
 
 ## PERIPHERAL Inspector
 
@@ -209,7 +214,8 @@ For more information, refer to the
 
 ## Memory Inspector
 
-The Eclipse CDT Cloud **Memory Inspector** provides a powerful and configurable memory viewer that works with debug adapters.
+The Eclipse CDT Cloud **Memory Inspector** provides a powerful and configurable memory viewer that works with
+debug adapters.
 
 ![Memory Inspector](./images/memory-inspector.png)
 
@@ -245,24 +251,25 @@ The **Disassembly View** shows the program execution in assembly code intermixed
 To open the **Disassembly View**:
 
 - press **Ctrl/Cmd + Shift + p** and select "Open Disassembly View" or
-
 - Right-click an item in the [**CALL STACK section**](#call-stack-section) and select "Open Disassembly View"
 
 ![Disassembly View](./images/disassembly-view.png)
 
 ## Debug Console
 
-The **Debug Console** enables viewing and interacting with the output of your code running in the debugger. Expressions can
+The **Debug Console** enables viewing and interacting with the output of your code running in the debugger.
+Expressions can
 be evaluated with the **Debug Console REPL** (Read-Eval-Print Loop) feature.
 
 With the CMSIS Debug extension, you can use the Debug Console REPL to enter
-[GDB commands](https://sourceware.org/gdb/current/onlinedocs/gdb.html/index.html) while debugging. Before entering a GDB
-command, you have to explicitly enter a "greater-than"-character `>` so that the following strings can be evaluated as a GDB
-command.
+[GDB commands](https://sourceware.org/gdb/current/onlinedocs/gdb.html/index.html) while debugging. Before entering
+a GDB command, you have to explicitly enter a "greater-than"-character `>` so that the following strings can be
+evaluated as a GDB command.
 
 Debug Console input uses the mode of the active editor, which means that it supports syntax coloring, indentation, auto
 closing of quotes, and other language features.
 
+<!-- markdownlint-disable-next-line MD036 -->
 **Example**
 
 The following example shows how to check the currently set breakpoints with the `> info break` command. Afterwards, the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,35 @@
 # Arm CMSIS Debugger extension
 
-The **Arm CMSIS Debugger** extension pack available in Visual Studio Code provides tools to debug projects built with the
-[CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/). It contains a set of extensions that are required to
-create the debug environment and is shipped with [pyOCD](https://pyocd.io/) and a GDB frontend.
+The **Arm CMSIS Debugger** extension pack available in Visual Studio Code provides tools to debug projects built with
+the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/). It contains a set of extensions that are
+required to create the debug environment and is shipped with [pyOCD](https://pyocd.io/) and a GDB frontend.
 
 The following extensions are included in this extension pack:
 
-- [CDT™ GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode), an Eclipse CDT.cloud extension that supports debugging using GDB and any other debuggers that support the MI protocol.
+- [CDT™ GDB Debug Adapter Extension](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode),
+an Eclipse CDT.cloud extension that supports debugging using GDB and any other debuggers that support the MI protocol.
 
-- [Memory Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector), an Eclipse CDT.cloud extension that provides a powerful and configurable memory viewer that works with debug adapters.
+- [Memory Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector),
+an Eclipse CDT.cloud extension that provides a powerful and configurable memory viewer that works with debug adapters.
 
-- [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector), an Eclipse CDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
+- [Peripheral Inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.peripheral-inspector),
+an Eclipse CDT.cloud extension that provides a CMSIS SVD viewer and works with debug adapters.
 
 ## Recommended extensions
 
 We recommend installing the following extensions to simplify the user experience:
 
-- [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager), an extension that allows you to download, install, and manage software development tools using [Microsoft® Vcpkg](https://vcpkg.io/en/index.html) artifacts. For example, use this extension to install the [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) which comes with a GDB variant for Arm CPUs.
+- [Arm Tools Environment Manager](https://marketplace.visualstudio.com/items?itemName=Arm.environment-manager), an 
+extension that allows you to download, install, and manage software development tools using
+[Microsoft® Vcpkg](https://vcpkg.io/en/index.html) artifacts. For example, use this extension to install the
+[Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) which comes with a GDB
+variant for Arm CPUs.
 
-- [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution), an extension that is a graphical user interface for csolution projects that use the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/). Use this extension to build your csolution projects, to generate `*.cbuild-run.yml` debug configuration files, and to make use of contributed commands in your debug launch configurations.
+- [Arm CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution), an extension that is a
+graphical user interface for csolution projects that use the
+[CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/). Use this extension to build your csolution
+projects, to generate `*.cbuild-run.yml` debug configuration files,
+and to make use of contributed commands in your debug launch configurations.
 
 ## Supported debug probes
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,9 +1,7 @@
 # Setup
 
-<!-- markdownlint-disable MD036 -->
-
-This chapter describes how to install the **Arm CMSIS Debugger** extension pack and how to configure the debug connection
-for single- and multi-core devices.
+This chapter describes how to install the **Arm CMSIS Debugger** extension pack and how to configure the debug
+connection for single- and multi-core devices.
 
 ## Installation
 
@@ -15,11 +13,12 @@ The **Arm CMSIS Debugger** extension pack includes extensions that you can use t
 
 ## Debug Setup
 
-The debug setup requires a GDB installation supporting the GDB remote protocol and that can connect to a GDB server like pyOCD.
+The debug setup requires a GDB installation supporting the GDB remote protocol and that can connect to a GDB
+server like pyOCD.
 
-We recommend installing the [`Arm GNU Toolchain`](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) using the
-`Arm Tools Environment Manager` extension. It comes with `arm-none-eabi-gdb` which is used in the Arm CMSIS Debugger default
-debug configurations.
+We recommend installing the [`Arm GNU Toolchain`](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain)
+using the `Arm Tools Environment Manager` extension. It comes with `arm-none-eabi-gdb` which is used in the Arm
+CMSIS Debugger default debug configurations.
 
 ### pyOCD Debug Setup
 
@@ -37,8 +36,8 @@ Install the latest [J-LINK Software and Documentation Pack](https://www.segger.c
 from [SEGGER](https://www.segger.com/). Ensure all required drivers and host platform specific settings are done.
 
 The extension expects the installation folder to be on your system `PATH` environment variable. Alternatively, update your
-debug configuration's `target`>`server` setting to contain the full path to the J-LINK GDB server executable (including the file
-name).
+debug configuration's `target`>`server` setting to contain the full path to the J-LINK GDB server executable
+(including the file name).
 
 The `cmsis-debug-jlink` debugger type is used to add a debug configuration in the `launch.json` file for debug with GDB and
 the SEGGER J-LINK GDB server. This configuration uses the `gdbtarget` debugger type registered by the CDT GDB Debug Adapter
@@ -69,8 +68,8 @@ binary files in the correct formats. Thus, you need to amend your project's `*.c
     For other toolchains, please consult the reference manual on how to generate DWARF Version 5 formatted ELF files.
 
 - In addition to generating an ELF file, you also need to create a [HEX](https://developer.arm.com/documentation/ka003292/latest/)
-  file that will be used to flash the firmware image. Add the following to any of your `*.cproject.yml` files (at the end of
-  the file):
+  file that will be used to flash the firmware image. Add the following to any of your `*.cproject.yml` files
+  (at the end of the file):
 
 ```yml
   output:

--- a/docs/tpip-header.md
+++ b/docs/tpip-header.md
@@ -1,2 +1,1 @@
 # TPIP Report for vscode-cmsis-debugger
-


### PR DESCRIPTION
## Changes
- **This change introduces an automated Markdown linter and link checker job.**
The goal is to ensure that all changes to Markdown files follow consistent formatting standards and that any URLs included are valid and reachable. If any issues are detected, the workflow will fail and provide detailed output, highlighting the exact lines with errors along with clear error messages. 

