### PR TITLE
Add CMSIS Debugger help

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
         "icon": "$(book)"
       }      
     ],
+    "submenus": [
+      {
+        "id": "vscode-cmsis-debugger.helpSubMenu",
+        "label": "Help SubMenu"
+      }
+    ],
     "menus": {
       "commandPalette": [
         {
@@ -61,9 +67,15 @@
       ],
       "view/title": [
         {
-          "command": "vscode-cmsis-debugger.openHelp",
+          "submenu": "vscode-cmsis-debugger.helpSubMenu",
           "when": "view == cmsis-csolution.outline",
           "group": "SolutionHelp@100"
+        }
+      ],
+      "vscode-cmsis-debugger.helpSubMenu": [
+        {
+          "command": "vscode-cmsis-debugger.openHelp",
+          "when": "view == cmsis-csolution.outline"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,26 @@
     "onStartupFinished"
   ],
   "contributes": {
+    "commands": [
+      {
+        "category": "CMSIS",
+        "command": "vscode-cmsis-debugger.open-manual",
+        "title": "Open CMSIS Debugger manual",
+        "icon": "$(book)"
+      }      
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "vscode-cmsis-debugger.open-manual"
+        }
+      ],
+      "debug/toolBar": [
+        {
+          "command": "vscode-cmsis-debugger.open-manual"
+        }
+      ]
+    },
     "debuggers": [
       {
         "type": "cmsis-debug-pyocd",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "commands": [
       {
         "category": "CMSIS",
-        "command": "vscode-cmsis-debugger.open-manual",
-        "title": "Open CMSIS Debugger manual",
+        "command": "vscode-cmsis-debugger.openHelp",
+        "title": "Help - CMSIS Debugger",
         "icon": "$(book)"
       }      
     ],
@@ -57,6 +57,12 @@
       "commandPalette": [
         {
           "command": "vscode-cmsis-debugger.open-manual"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "vscode-cmsis-debugger.open-manual",
+          
         }
       ],
       "debug/toolBar": [

--- a/package.json
+++ b/package.json
@@ -56,18 +56,14 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "vscode-cmsis-debugger.open-manual"
+          "command": "vscode-cmsis-debugger.openHelp"
         }
       ],
       "view/title": [
         {
-          "command": "vscode-cmsis-debugger.open-manual",
-          
-        }
-      ],
-      "debug/toolBar": [
-        {
-          "command": "vscode-cmsis-debugger.open-manual"
+          "command": "vscode-cmsis-debugger.openHelp",
+          "when": "view == cmsis-csolution.outline",
+          "group": "SolutionHelp@100"
         }
       ]
     },

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -29,12 +29,12 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
     gdbtargetDebugTracker.activate(context);
     gdbtargetConfigurationProvider.activate(context);
 
-    const manualHandler = () => {
+    const openHelpHandler = () => {
         logger.warn('DOCS OPEN');
     };
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('vscode-cmsis-debugger.open-manual', manualHandler)
+        vscode.commands.registerCommand('vscode-cmsis-debugger.openHelp', openHelpHandler)
     );
 
     logger.debug('Extension Pack activated');

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -29,5 +29,13 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
     gdbtargetDebugTracker.activate(context);
     gdbtargetConfigurationProvider.activate(context);
 
+    const manualHandler = () => {
+        logger.warn('DOCS OPEN');
+    };
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vscode-cmsis-debugger.open-manual', manualHandler)
+    );
+
     logger.debug('Extension Pack activated');
 };


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- #244 

## Changes
<!-- List the changes this PR introduces -->

- Bit of an early play where to place access to the help, command is a mockup only. At the moment
  - Command Palette
  - CMSIS Solution Extension Outline view
- Unfortunately not good contribution points available at the moment in "Run and Debug".

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

Command Palette
![image](https://github.com/user-attachments/assets/411d5bcf-a38c-4ae1-80a0-8c8ca6241998)

CMSIS Solution Extension Outline view
![image](https://github.com/user-attachments/assets/db8a59f5-de55-4ab4-84af-2895eff51a4e)

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

<!-- TODO: Add a checklist -->
