### PR TITLE
Fine grained permissions for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
     runs-on: [ubuntu-latest]
     if: github.event_name == 'release'
     needs: package
+    permissions:
+      contents: write  # for softprops/action-gh-release to create a GitHub release
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
## Changes
- Need to have `content: write` permissions for release action
