### PR TITLE
Remove pre-release flag from packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,9 @@ jobs:
           yarn --frozen-lockfile --ignore-scripts --prefer-offline
           yarn download-tools --target ${{ matrix.target }} --no-cache
 
-      - name: Create vsix package (pre-release)
+      - name: Create vsix package
         run: |
-          yarn package --target ${{ matrix.target }} --pre-release
+          yarn package --target ${{ matrix.target }}
 
       - name: Upload package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Switch away from `pre-release` distribution channel. Extension remains at `preview` status.
 - Included [Microsoft® Serial `Monitor`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-serial-monitor)
 in extension pack.
 


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#<Number>](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/<number>)

## Changes
<!-- List the changes this PR introduces -->

Switch from pre-releases to full releases. But stay on `preview` status.
Technicality to include this extension properly into extension packs that are past the `pre-release` stage.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

