### PR TITLE
Prevent workflows from running on doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
   merge_group:
   release:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,8 @@
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read
@@ -15,5 +18,6 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,8 @@ on:
     - cron: '0 0 * * *'
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -7,9 +7,9 @@ on:
       - docs/third-party-licenses.json
       - docs/tpip-header.md
       - scripts/tpip-reporter.ts
+      - '!**/*.md'
     branches:
       - main
-    
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
##Fix:
- Prevented irrelevant CI jobs from running when only documentation (`.md`) files are changed.
- Normalized line endings in `ci.yml` from CRLF to LF for consistency across environments.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

