### PR TITLE
Only show tool warning if trying to use built-in tools

### DIFF
--- a/src/debug-configuration/gdbtarget-configuration-provider.ts
+++ b/src/debug-configuration/gdbtarget-configuration-provider.ts
@@ -146,12 +146,19 @@ export class GDBTargetConfigurationProvider implements vscode.DebugConfiguration
     protected resolveGdbPath(config: GDBTargetConfiguration): void {
         const gdb = config.gdb;
         const useBuiltin = !gdb || ARM_NONE_EABI_GDB_EXECUTABLE_ONLY_REGEXP.test(gdb);
-        const updateUri = useBuiltin ? this.builtinArmNoneEabiGdb.getAbsolutePath() : undefined;
-        if (updateUri) {
-            config.gdb = updateUri.fsPath;
-        } else {
-            vscode.window.showWarningMessage(`Cannot find ${ARM_NONE_EABI_GDB_BUILTIN_PATH} in CMSIS Debugger installation.\nUsing ${ARM_NONE_EABI_GDB_NAME} from PATH instead.`);
+        if (!useBuiltin) {
+            // Leave as is
+            return;
         }
+        const updateUri = this.builtinArmNoneEabiGdb.getAbsolutePath();
+        if (!updateUri) {
+            const warnMessage =
+                `Cannot find './${ARM_NONE_EABI_GDB_BUILTIN_PATH}' in CMSIS Debugger extension installation.\n`
+                + `Using ${ARM_NONE_EABI_GDB_NAME} from PATH instead.`;
+            vscode.window.showWarningMessage(warnMessage);
+            return;
+        }
+        config.gdb = updateUri.fsPath;
     }
 
 }

--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
@@ -36,12 +36,19 @@ export class PyocdConfigurationProvider extends BaseConfigurationProvider {
     protected resolveServerPath(target: TargetConfiguration): void {
         const targetServer = target.server;
         const useBuiltin = !targetServer || PYOCD_EXECUTABLE_ONLY_REGEXP.test(targetServer);
-        const updateUri = useBuiltin ? this.builtinPyocd.getAbsolutePath() : undefined;
-        if (updateUri) {
-            target.server = updateUri.fsPath;
-        } else {
-            vscode.window.showWarningMessage(`Cannot find ${PYOCD_BUILTIN_PATH} in CMSIS Debugger installation.\nUsing ${PYOCD_NAME} from PATH instead.`);
+        if (!useBuiltin) {
+            // Leave as is
+            return;
         }
+        const updateUri = this.builtinPyocd.getAbsolutePath();
+        if (!updateUri) {
+            const warnMessage =
+                `Cannot find './${PYOCD_BUILTIN_PATH}' in CMSIS Debugger extension installation.\n`
+                + `Using ${PYOCD_NAME} from PATH instead.`;
+            vscode.window.showWarningMessage(warnMessage);
+            return;
+        }
+        target.server = updateUri.fsPath;
     }
 
     protected resolveCmsisPackRootPath(target: TargetConfiguration): void {


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- #407 

## Changes
<!-- List the changes this PR introduces -->

- Fixing condition under which to show the warning that built-in tools are not present in extension installation.
- Slightly refine warning message, should never be visible in healthy user installation.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

