### PR TITLE
1.0.0-pre0 Release Preparations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       matrix:
         target:
           - win32-x64
+          - win32-arm64
           - linux-x64
           - linux-arm64
           - darwin-arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 - Updates included pyOCD distribution to v0.38.0
     - Implements [#313](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/313): Add CoreSight AP specific CSW handling for AHB-AP, AXI-AP, APB-AP.
     - Cortex-M: configure AP for cacheable access when cache is present.
-    - Add support for SW breakpoints when cache is present
+    - Add support for SW breakpoints when cache is present.
     - Add more debug logging information for cbuild-run targets.
     - Fixes [#108](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/108): Flash algorithms - Relax memory layout rules and add RAM alignment and minimum stack size checking.
     - Fixes [#382](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/382): CMSIS-DAP probe: fix macOS HID read/write.
-    - Fixes [#387](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/387): cbuild-run: use cbuild-run.yml parent folder as working directory for relative paths
-    - Fixes: Flash region builder - remove flash algorithm page size adjustment
+    - Fixes [#387](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/387): cbuild-run: use cbuild-run.yml parent folder as working directory for relative paths.
+    - Fixes: Flash region builder - remove flash algorithm page size adjustment.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log
 
-## Unreleased
+## 1.0.0
 
+- Removes `Preview` status from extension.
 - Fixes [#407](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/407): Warning pops up when using an absolute path in the launch config.
+- Fixes [#428](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/428): `PERIPHERALS` view not shown when attaching to a running debug session.
+- Implements [#357](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/357): Create extension variant for Windows on Arm (WoA).
+- Updates included pyOCD distribution to v0.38.0
+    - Implements [#313](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/313): Add CoreSight AP specific CSW handling for AHB-AP, AXI-AP, APB-AP.
+    - Cortex-M: configure AP for cacheable access when cache is present.
+    - Add support for SW breakpoints when cache is present
+    - Add more debug logging information for cbuild-run targets.
+    - Fixes [#108](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/108): Flash algorithms - Relax memory layout rules and add RAM alignment and minimum stack size checking.
+    - Fixes [#382](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/382): CMSIS-DAP probe: fix macOS HID read/write.
+    - Fixes [#387](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/387): cbuild-run: use cbuild-run.yml parent folder as working directory for relative paths
+    - Fixes: Flash region builder - remove flash algorithm page size adjustment
 
 ## 0.5.0
 

--- a/TPIP.md
+++ b/TPIP.md
@@ -1,9 +1,9 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Report prepared at: 30/07/2025, 09:14:56
+Report prepared at: 30/07/2025, 14:00:04
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|
 | arm-none-eabi-gdb | 14.3.1 | https://artifacts.tools.arm.com/arm-none-eabi-gdb/14.3.1/ | https://developer.arm.com/GetEula?Id=15d9660a-2059-4985-85e9-c01cdd4b1ba0 |
-| pyocd | 0.38.0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE |
+| pyocd | 0.38.0-pre0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.38.0-pre0/LICENSE |
 | yaml | 2.8.0 | https://github.com/eemeli/yaml | https://github.com/eemeli/yaml/blob/main/LICENSE |

--- a/TPIP.md
+++ b/TPIP.md
@@ -1,9 +1,9 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Report prepared at: 21/07/2025, 09:18:50
+Report prepared at: 30/07/2025, 09:14:56
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|
 | arm-none-eabi-gdb | 14.3.1 | https://artifacts.tools.arm.com/arm-none-eabi-gdb/14.3.1/ | https://developer.arm.com/GetEula?Id=15d9660a-2059-4985-85e9-c01cdd4b1ba0 |
-| pyocd | 0.37.0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.37.0/LICENSE |
+| pyocd | 0.38.0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE |
 | yaml | 2.8.0 | https://github.com/eemeli/yaml | https://github.com/eemeli/yaml/blob/main/LICENSE |

--- a/docs/third-party-licenses.json
+++ b/docs/third-party-licenses.json
@@ -8,10 +8,10 @@
     },
     {
         "name": "pyocd",
-        "version": "0.38.0",
+        "version": "0.38.0-pre0",
         "spdx": "Apache-2.0",
         "url": "https://github.com/pyocd/pyOCD",
-        "license": "https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE"
+        "license": "https://github.com/pyocd/pyOCD/blob/v0.38.0-pre0/LICENSE"
     },
     {
         "name": "yaml",

--- a/docs/third-party-licenses.json
+++ b/docs/third-party-licenses.json
@@ -8,10 +8,10 @@
     },
     {
         "name": "pyocd",
-        "version": "0.37.0",
+        "version": "0.38.0",
         "spdx": "Apache-2.0",
         "url": "https://github.com/pyocd/pyOCD",
-        "license": "https://github.com/pyocd/pyOCD/blob/v0.37.0/LICENSE"
+        "license": "https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE"
     },
     {
         "name": "yaml",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "vscode-cmsis-debugger",
   "displayName": "Arm CMSIS Debugger",
   "description": "Run and debug embedded and IoT projects on Arm Cortex-M single or multi core devices. Connects via pyOCD to CMSIS-DAP or other GDB servers.",
-  "version": "0.5.0",
-  "preview": true,
+  "version": "1.0.0-pre0",
+  "preview": false,
   "publisher": "Arm",
   "author": "Jens Reinecke <jens.reinecke@arm.com>",
   "license": "SEE LICENSE IN LICENSE",
@@ -151,7 +151,7 @@
     "yargs": "^18.0.0"
   },
   "cmsis": {
-    "pyocd": "pyocd/pyOCD@0.37.0",
+    "pyocd": "pyocd/pyOCD@0.38.0-pre0",
     "gdb": "14.3.1"
   }
 }


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Preparations to create a pre-release for debug solution testing prior to 1.0.0 release.
- Includes pyOCD 0.38.0-pre0
- CHANGELOG updates as for 1.0.0 release (no `pre0` in version).
- TPIP updates for pyOCD 0.38.0-pre0 to keep CI happy.

No more planned changes in this release for 1.0.0. Work on CDT GDB adapter is ongoing.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

