### PR TITLE
1.0.0 Release Preparations

### DIFF
--- a/TPIP.md
+++ b/TPIP.md
@@ -1,9 +1,9 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Report prepared at: 30/07/2025, 14:00:04
+Report prepared at: 30/07/2025, 14:15:50
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|
 | arm-none-eabi-gdb | 14.3.1 | https://artifacts.tools.arm.com/arm-none-eabi-gdb/14.3.1/ | https://developer.arm.com/GetEula?Id=15d9660a-2059-4985-85e9-c01cdd4b1ba0 |
-| pyocd | 0.38.0-pre0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.38.0-pre0/LICENSE |
+| pyocd | 0.38.0 | https://github.com/pyocd/pyOCD | https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE |
 | yaml | 2.8.0 | https://github.com/eemeli/yaml | https://github.com/eemeli/yaml/blob/main/LICENSE |

--- a/docs/third-party-licenses.json
+++ b/docs/third-party-licenses.json
@@ -8,10 +8,10 @@
     },
     {
         "name": "pyocd",
-        "version": "0.38.0-pre0",
+        "version": "0.38.0",
         "spdx": "Apache-2.0",
         "url": "https://github.com/pyocd/pyOCD",
-        "license": "https://github.com/pyocd/pyOCD/blob/v0.38.0-pre0/LICENSE"
+        "license": "https://github.com/pyocd/pyOCD/blob/v0.38.0/LICENSE"
     },
     {
         "name": "yaml",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cmsis-debugger",
   "displayName": "Arm CMSIS Debugger",
   "description": "Run and debug embedded and IoT projects on Arm Cortex-M single or multi core devices. Connects via pyOCD to CMSIS-DAP or other GDB servers.",
-  "version": "1.0.0-pre0",
+  "version": "1.0.0",
   "preview": false,
   "publisher": "Arm",
   "author": "Jens Reinecke <jens.reinecke@arm.com>",


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Prepare TPIP information for update to pyOCD 0.38.0.
- Prepare extension version for 1.0.0 release.

TODO
- Update pyOCD to yet to be made 0.38.0 release. This will also make MD link check failures go away.
- Review CHANGELOG and README as needed for upcoming release.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

