### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   build:
@@ -37,6 +36,8 @@ jobs:
           - platform: macos-14
             target: darwin
     runs-on: ${{ matrix.platform }}
+    permissions:
+      packages: read
     name: 'Build and test (${{ matrix.target }})'
 
     steps:
@@ -164,6 +165,8 @@ jobs:
           - linux-x64
           - linux-arm64
           - darwin-arm64
+    permissions:
+      packages: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -16,10 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   report:
     permissions:
-      contents: write  # for Git to git push
+      # contents: write  # for Git to git push # disabled until resurrecting direct git push
       packages: read
 
     name: Generate report


### PR DESCRIPTION
## Addresses
<!-- List the GitHub issue this PR resolves -->

- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/code-scanning/1
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/code-scanning/6
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/code-scanning/21

## Changes
<!-- List the changes this PR introduces -->

- Restore global permissions for all workflows to be only "contents: read" as suggested by best practices. Got changed with a recent PR.
- Disable "contents: write" for TPIP workflow until git push gets resurrected.

Other flagged security warnings had been dismissed as "won't fix" before. They can't be avoided to keep the needed level of CI automation.
@soumeh01 , curious if we can add ignore-comments to the workflows similar to our linters. Given we'll never change the workflows but issues can be re-raised.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

