### PR TITLE
Attach release assets from correct path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,18 +249,14 @@ jobs:
         with:
           pattern: test-report-linux
 
-      - name: Zip test report
-        run: zip -r test-report.zip *
-        working-directory: test-report-linux
-
       - name: Zip test coverage
         run: zip -r test-coverage.zip *
-        working-directory: test-coverage
+        working-directory: coverage
          
       - name: Attach packages
         uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
         with:
           files: |
             **/*.vsix
-            test-coverage/test-coverage.zip
-            test-report-linux/test-report.zip
+            coverage/test-coverage.zip
+            test-report.html


### PR DESCRIPTION
## Changes
- Need to adapt workflows because of the breaking change in `download-artifact` action listed in https://github.com/actions/download-artifact/releases

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

