### PR TITLE
Live watch fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
       "editor/context": [
         {
           "command": "vscode-cmsis-debugger.liveWatch.addToLiveWatchFromTextEditor",
-          "when": "editorTextFocus && editorHasSelection",
+          "when": "editorTextFocus",
           "group": "z_commands"
         }
       ],
@@ -239,7 +239,7 @@
       "view/item/context": [
         {
           "command": "vscode-cmsis-debugger.liveWatch.modify",
-          "when": "view == cmsis-debugger.liveWatch",
+          "when": "view == cmsis-debugger.liveWatch && viewItem == parentExpression",
           "group": "inline@1"
         },
         {
@@ -254,7 +254,7 @@
         },
         {
           "command": "vscode-cmsis-debugger.liveWatch.modify",
-          "when": "view == cmsis-debugger.liveWatch",
+          "when": "view == cmsis-debugger.liveWatch && viewItem == parentExpression",
           "group": "contextMenuG1@2"
         },
         {
@@ -279,7 +279,7 @@
         },
         {
           "command": "vscode-cmsis-debugger.liveWatch.showInMemoryInspector",
-          "when": "view == cmsis-debugger.liveWatch && viewItem == parentExpression",
+          "when": "view == cmsis-debugger.liveWatch",
           "group": "contextMenuG3@1"
         }
       ]

--- a/src/views/live-watch/live-watch.test.ts
+++ b/src/views/live-watch/live-watch.test.ts
@@ -230,7 +230,7 @@ describe('LiveWatchTreeDataProvider', () => {
 
         it('AddFromSelection adds selected text as new live watch expression to roots', async () => {
             jest.spyOn(liveWatchTreeDataProvider as any, 'evaluate').mockResolvedValue({ result: '5678', variablesReference: 0 });
-            // Mock the active text editor with a selection
+            // Mock the active text editor with fake range
             const fakeRange = { start: { line: 0, character: 0 }, end: { line: 0, character: 17 } };
             const mockEditor: any = {
                 document: {
@@ -247,7 +247,7 @@ describe('LiveWatchTreeDataProvider', () => {
             await (liveWatchTreeDataProvider as any).handleAddFromSelectionCommand();
             const roots = (liveWatchTreeDataProvider as any).roots;
             expect(mockEditor.document.getWordRangeAtPosition).toHaveBeenCalledWith(mockEditor.selection.active);
-            expect(mockEditor.document.getText).toHaveBeenCalledWith(mockEditor.selection);
+            expect(mockEditor.document.getText).toHaveBeenCalledWith(fakeRange);
             expect(roots.length).toBe(1);
             expect(roots[0].expression).toBe('selected-expression');
             expect(roots[0].value.result).toBe('5678');

--- a/src/views/live-watch/live-watch.ts
+++ b/src/views/live-watch/live-watch.ts
@@ -83,7 +83,6 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
     public getTreeItem(element: LiveWatchNode): vscode.TreeItem {
         const item = new vscode.TreeItem(element.expression + ' = ');
         item.description = element.value.result;
-        item.contextValue = 'expression';
         item.tooltip = element.value.type ?? '';
         item.collapsibleState = element.value.variablesReference !== 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
         item.contextValue = element.parent ? 'childExpression' : 'parentExpression';
@@ -217,11 +216,8 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
         }
         const selection = editor.selection;
         const document = editor.document;
-        if (document.getWordRangeAtPosition(selection.active) === undefined) {
-            // user selected more than a single line
-            return;
-        }
-        const selectedText = document.getText(selection).trim();
+        const range = document.getWordRangeAtPosition(selection.active);
+        const selectedText = range ? document.getText(range).trim() : '';
         if (!selectedText) {
             return;
         }
@@ -248,14 +244,14 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
         const args = {
             sessionId: this._activeSession?.session.id,
             container: {
-                name: node.expression,
+                name: node.value.evaluateName ?? node.expression,
                 variablesReference: node.value.variablesReference
             },
             variable: {
-                name: node.expression,
+                name: node.value.evaluateName ?? node.expression,
                 value: node.value.result,
                 variablesReference: node.value.variablesReference,
-                memoryReference: `&(${node.expression})`
+                memoryReference: `&(${node.value.evaluateName ?? node.expression})`
             }
         };
         await vscode.commands.executeCommand('memory-inspector.show-variable', args);


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#609 ](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/609)

## Changes
<!-- List the changes this PR introduces -->

- Removed delete button for child elements, it's only available for parent elements now
- If the user would like to add a child expression from variables window or watch window to the Live Watch window, the element added to the Live Watch will include the parent as well.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

