### PR TITLE
Remove automatic insertion of --port server argument for pyOCD

### DIFF
--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.test.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.test.ts
@@ -34,7 +34,7 @@ describe('PyocdConfigurationProvider', () => {
             expect(gdbtargetConfig?.target?.serverParameters).not.toContain('--port');
         });
 
-        it('adds port to server parameters, gdbserver always gets added', async () => {
+        it('always adds gdbserver, does not add port to server parameters', async () => {
             const configProvider = new PyocdConfigurationProvider();
             const config = gdbTargetConfiguration({
                 target: targetConfigurationFactory({ port: '4711' }),
@@ -43,16 +43,16 @@ describe('PyocdConfigurationProvider', () => {
             expect(debugConfig).toBeDefined();
             const gdbtargetConfig = debugConfig as GDBTargetConfiguration;
             expect(gdbtargetConfig?.target?.serverParameters).toContain('gdbserver');
-            expect(gdbtargetConfig?.target?.serverParameters).toContain('--port');
-            expect(gdbtargetConfig?.target?.serverParameters).toContain('4711');
+            // GDB port expected to come through *.cbuild-run.yml file.
+            expect(gdbtargetConfig?.target?.serverParameters).not.toContain('--port');
         });
 
-        it('does not overwrite port in server parameters', async () => {
+        it('keeps port from config in server parameters', async () => {
             const configProvider = new PyocdConfigurationProvider();
             const config = gdbTargetConfiguration({
                 target: targetConfigurationFactory({
                     port: '4711',
-                    serverParameters: ['-port', '10815'],
+                    serverParameters: ['--port', '10815'],
                 }),
             });
             const debugConfig = await configProvider.resolveDebugConfigurationWithSubstitutedVariables(undefined, config, undefined);

--- a/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
+++ b/src/debug-configuration/subproviders/pyocd-configuration-provider.ts
@@ -27,7 +27,6 @@ const PYOCD_EXECUTABLE_ONLY_REGEXP = /^\s*pyocd(|.exe)\s*$/i;
 export const PYOCD_SERVER_TYPE_REGEXP = /.*pyocd(|.exe)\s*$/i;
 
 const PYOCD_CLI_ARG_GDBSERVER = 'gdbserver';
-const PYOCD_CLI_ARG_PORT = '--port';
 const PYOCD_CLI_ARG_CBUILDRUN = '--cbuild-run';
 
 export class PyocdConfigurationProvider extends BaseConfigurationProvider {
@@ -56,11 +55,6 @@ export class PyocdConfigurationProvider extends BaseConfigurationProvider {
         if (await this.shouldAppendParameter(parameters, PYOCD_CLI_ARG_GDBSERVER)) {
             // Prepend, it must be the first argument
             parameters.unshift(PYOCD_CLI_ARG_GDBSERVER);
-        }
-        // port (use value defined in 'port' outside 'serverParamters')
-        const port = debugConfiguration.target?.port;
-        if (port && await this.shouldAppendParameter(parameters, PYOCD_CLI_ARG_PORT)) {
-            parameters.push(PYOCD_CLI_ARG_PORT, `${port}`);
         }
         // cbuild-run
         const cbuildRunFile = debugConfiguration.cmsis?.cbuildRunFile;


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- Related to but not completing #338 
- `--port` server parameter causing trouble with coming changes to pyOCD on automatic port allocation.

## Changes
<!-- List the changes this PR introduces -->

- Removes inserting `--port` in pyOCD `serverParameters` list based on `target`>`port` value if present.
- From now on, this has to be explicitly added to the `serverParameters`.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

