### PR TITLE
Inform user if stopping 'launch' session may impact still running 'attach' sessions

### DIFF
--- a/src/debug-session/gdbtarget-debug-session.ts
+++ b/src/debug-session/gdbtarget-debug-session.ts
@@ -20,6 +20,9 @@ import { logger } from '../logger';
 import { CbuildRunReader } from '../cbuild-run';
 import { PeriodicRefreshTimer } from './periodic-refresh-timer';
 import { OutputEventFilter } from './output-event-filter';
+import { URI } from 'vscode-uri';
+import { GDBTargetConfiguration } from '../debug-configuration';
+import path from 'path';
 
 /**
  * GDBTargetDebugSession - Wrapper class to provide session state/details
@@ -53,6 +56,14 @@ export class GDBTargetDebugSession {
             event.event = 'cmsis-debugger-discarded'; // Discard the event by changing the event name
             return;
         }
+    }
+
+    public getCbuildRunPath(): string | undefined {
+        const cbuildRunFile = (this.session.configuration as GDBTargetConfiguration)?.cmsis?.cbuildRunFile;
+        if (!cbuildRunFile) {
+            return undefined;
+        }
+        return path.normalize(URI.file(cbuildRunFile).fsPath);
     }
 
     public async getCbuildRun(): Promise<CbuildRunReader|undefined> {


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- Part of #685 

## Changes
<!-- List the changes this PR introduces -->

- Detect on `terminate`, `disconnect`, `restart` requests if other related sessions are still running and in danger of becoming unstable.
- Show a modal dialog to close and restart session if it becomes unstable.

TODO:
* Receiving both `terminate` and `disconnect` for stop causes the modal dialog to show twice. Needs to be debounced (...although it could be considered as a tribute to uVision's duplicate connection error popups).
* Cleanup, refactor, and alignment of functionality with #696 
* Tests

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

<img width="460" height="112" alt="image" src="https://github.com/user-attachments/assets/3544ca91-ec0d-49c3-ba1a-1a5f93e52ac0" />


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

