### PR TITLE
Change smells reporting mode from comment to review

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -16,7 +16,7 @@ test_patterns = [
 # === Smells Configuration ===
 # Controls how detected code smells are reported
 [smells]
-mode = "comment"          # Adds comments in code or PRs to report smells
+mode = "review"           # Adds review comments once without duplicating on subsequent commits
 
 # === Source Configuration ===
 # Defines a code source for analysis


### PR DESCRIPTION
## Changes
- The `review` mode is designed to prevent duplicate comments by tracking which issues have already been reported, whereas `comment` mode would add comments every time regardless of whether they were already present. I would try this change and monitor if this actually resolves the issue.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

