### PR TITLE
remove all global mocks from component viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,16 +342,7 @@
           }
         }
       }
-    ],
-    "configuration": {
-      "properties": {
-        "vscode-cmsis-debugger.useMocks": {
-          "type": "boolean",
-          "default": false,
-          "description": "If enabled, CMSIS Debugger uses mock data for testing and development purposes."
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "prepare": "yarn run build",

--- a/src/views/component-viewer/component-viewer-controller.ts
+++ b/src/views/component-viewer/component-viewer-controller.ts
@@ -18,42 +18,7 @@ import * as vscode from 'vscode';
 import { GDBTargetDebugTracker, GDBTargetDebugSession, SessionStackItem } from '../../debug-session';
 import { ComponentViewerInstance } from './component-viewer-instance';
 import { URI } from 'vscode-uri';
-import path from 'path';
 import { ComponentViewerTreeDataProvider } from './component-viewer-tree-view';
-
-const scvdMockTestFiles: Map<string, boolean> = new Map<string, boolean>([
-    ['src/component-viewer/test/test-files/scvd/MinimalTest.scvd',      true],
-    ['src/component-viewer/test/test-files/scvd/MyTest.scvd',           false],
-    ['src/component-viewer/test/test-files/scvd/RTX5.scvd',             false],
-    ['src/component-viewer/test/test-files/scvd/BaseExample.scvd',      false],
-    ['src/component-viewer/test/test-files/scvd/Network.scvd',          false],
-    ['src/component-viewer/test/test-files/scvd/USB.scvd',              false],
-    ['src/component-viewer/test/test-files/scvd/FileSystem.scvd',       false],
-    ['src/component-viewer/test/test-files/scvd/EventRecorder.scvd',    false],
-    ['src/component-viewer/test/test-files/scvd/GetRegVal_Test.scvd',   false],
-]);
-
-const scvdMockFiles: string[] = Array.from(scvdMockTestFiles.entries())
-    .filter(([_, include]) => include)
-    .map(([filePath]) => filePath);
-
-// Helper function to create a mock GDBTargetDebugSession for testing
-export function createMockDebugSession(): GDBTargetDebugSession {
-    const mockVSCodeSession: vscode.DebugSession = {
-        id: 'mock-session-id',
-        name: 'Mock Debug Session',
-        type: 'gdbtarget',
-        workspaceFolder: undefined,
-        configuration: {
-            type: 'gdbtarget',
-            name: 'Mock Debug Session',
-            request: 'launch'
-        },
-        customRequest: async () => ({}),
-        getDebugProtocolBreakpoint: async () => undefined
-    };
-    return new GDBTargetDebugSession(mockVSCodeSession);
-}
 
 
 export class ComponentViewerController {
@@ -61,9 +26,6 @@ export class ComponentViewerController {
     private instances: ComponentViewerInstance[] = [];
     private componentViewerTreeDataProvider: ComponentViewerTreeDataProvider | undefined;
     private _context: vscode.ExtensionContext;
-    private mockFlag: boolean = true;
-    // Check if mocks shall be used from configuration
-    private useMocks = vscode.workspace.getConfiguration('vscode-cmsis-debugger').get('useMocks');
 
     public constructor(context: vscode.ExtensionContext) {
         this._context = context;
@@ -75,45 +37,8 @@ export class ComponentViewerController {
         const treeProviderDisposable = vscode.window.registerTreeDataProvider('cmsis-debugger.componentViewer', this.componentViewerTreeDataProvider);
         this._context.subscriptions.push(
             treeProviderDisposable);
-        // Subscribe to vscode event for changes in mocks configuration in the settings.json
-        vscode.workspace.onDidChangeConfiguration(async (event) => {
-            // Do an initial setup of mocks if useMocks is true and no instances are loaded yet
-            this.useMocks = vscode.workspace.getConfiguration('vscode-cmsis-debugger').get('useMocks');
-            if (this.instances.length === 0 && this.useMocks && this.mockFlag) {
-                this.mockFlag = false; // to avoid multiple initializations
-                await this.useMocksInstances(this._context);
-                await this.componentViewerTreeDataProvider?.activate();
-                return;
-            }
-            // if there are instances already loaded, check if the configuration changed
-            if (event.affectsConfiguration('vscode-cmsis-debugger.useMocks')) {
-                if (this.useMocks) {
-                    await this.useMocksInstances(this._context);
-                    await this.componentViewerTreeDataProvider?.activate();
-                } else {
-                    await this.componentViewerTreeDataProvider?.deleteModels();
-                }
-            }
-        });
         // Subscribe to debug tracker events to update active session
         this.subscribetoDebugTrackerEvents(this._context, tracker);
-    }
-
-    protected async buildMockInstancesArray(context: vscode.ExtensionContext): Promise<void> {
-        const mockedInstances: ComponentViewerInstance[] = [];
-        //const mockSession = createMockDebugSession();
-        for (const scvdFile of scvdMockFiles) {
-            const instance = new ComponentViewerInstance();
-            try {
-                // use a mocked GDBTargetDebugSession
-                await instance.readModel(URI.file(path.join(context.extensionPath, scvdFile)), createMockDebugSession(), new GDBTargetDebugTracker());
-            } catch (error) {
-                console.error('Error reading mock SCVD file:', scvdFile, error);
-                continue;
-            }
-            mockedInstances.push(instance);
-        }
-        this.instances = mockedInstances;
     }
 
     protected async readScvdFiles(tracker: GDBTargetDebugTracker,session?: GDBTargetDebugSession): Promise<void> {
@@ -138,15 +63,6 @@ export class ComponentViewerController {
             }
         }
         this.instances = cbuildRunInstances;
-    }
-
-    private async useMocksInstances(context: vscode.ExtensionContext) : Promise<void> {
-        await this.buildMockInstancesArray(context);
-        // Add all mock models to the tree view
-        for (const instance of this.instances) {
-            await instance.update();
-            this.componentViewerTreeDataProvider?.addGuiOut(instance.getGuiTree());
-        }
     }
 
     private loadingCounter: number = 0;
@@ -216,11 +132,6 @@ export class ComponentViewerController {
     }
 
     private async handleOnConnected(session: GDBTargetDebugSession, tracker: GDBTargetDebugTracker): Promise<void> {
-        // If mocks are being used, erase them and start reading SCVD files from cbuild-run
-        if ( this.instances.length > 0 && this.useMocks ) {
-            this.instances = [];
-            await this.componentViewerTreeDataProvider?.deleteModels();
-        }
         // if new session is not the current active session, erase old instances and read the new ones
         if (this.activeSession?.session.id !== session.session.id) {
             this.instances = [];

--- a/src/views/component-viewer/component-viewer-target-access.ts
+++ b/src/views/component-viewer/component-viewer-target-access.ts
@@ -18,30 +18,19 @@ import * as vscode from 'vscode';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { GDBTargetDebugSession } from '../../debug-session';
 import { logger } from '../../logger';
-import { createMockDebugSession } from './component-viewer-controller';
 
 
 export class ComponentViewerTargetAccess {
-    // Check if mocks shall be used from configuration
-    private useMocks = vscode.workspace.getConfiguration('vscode-cmsis-debugger').get('useMocks');
     _activeSession: GDBTargetDebugSession | undefined;
     constructor () {
-        if (this.useMocks) {
-            this._activeSession = createMockDebugSession();
-        } else if (vscode.debug.activeDebugSession) {
+        if (vscode.debug.activeDebugSession) {
             this._activeSession = new GDBTargetDebugSession(vscode.debug.activeDebugSession);
         }
     }
 
     // Function to reset active session
     public setActiveSession(session: GDBTargetDebugSession): void {
-        if (this.useMocks) {
-            this._activeSession = createMockDebugSession();
-            return;
-        } else {
-            this._activeSession = session;
-            return;
-        }
+        this._activeSession = session;
     }
 
     public async evaluateSymbolAddress(address: string, context = 'hover'): Promise<string | undefined> {


### PR DESCRIPTION
I removed the following mocks from the component viewer as they are not needed anymore.

1. Mock flows in the componentViewer controller
2. Debug Session mock
3. Mock boolean in the package.json file