### PR TITLE
Fix gui collapsing

### DIFF
--- a/src/views/component-viewer/component-viewer-controller.ts
+++ b/src/views/component-viewer/component-viewer-controller.ts
@@ -180,7 +180,7 @@ export class ComponentViewerController {
             this.updateSymaphorFlag = false;
             return;
         }
-        await this.componentViewerTreeDataProvider?.deleteModels();
+        this.componentViewerTreeDataProvider?.resetModelCache();
         for (const instance of this.instances) {
             this.instanceUpdateCounter++;
             console.log(`Updating Component Viewer Instance #${this.instanceUpdateCounter}`);

--- a/src/views/component-viewer/component-viewer-instance.ts
+++ b/src/views/component-viewer/component-viewer-instance.ts
@@ -135,7 +135,7 @@ export class ComponentViewerInstance {
         this.statementEngine = new StatementEngine(this.model, executionContext);
         this.statementEngine.initialize();
         stats.push(this.getStats('  statementEngine.initialize'));
-        this._guiTree = new ScvdGuiTree(undefined);
+        this._guiTree = new ScvdGuiTree(undefined, 'component-viewer-root');
 
         console.log('ComponentViewerInstance readModel stats:\n' + stats.join('\n  '));
     }

--- a/src/views/component-viewer/component-viewer-tree-view.ts
+++ b/src/views/component-viewer/component-viewer-tree-view.ts
@@ -44,28 +44,7 @@ export class ComponentViewerTreeDataProvider implements vscode.TreeDataProvider<
         this._scvdModel = { scvdGuiOut: [] };
     }
     public async activate(): Promise<void> {
-    //public async activate(tracker: GDBTargetDebugTracker): Promise<void> {
-        /*
-        // Subscribe to the debug tracker relevant events
-        const onDidChangeActiveDebugSessionDisposable = tracker.onDidChangeActiveDebugSession(
-            async (session) => await this.handleOnDidChangeActiveDebugSession(session)
-        );
-        const onWillStartSessionDisposable = tracker.onWillStartSession(
-            async (session) => await this.handleOnWillStartSession(session)
-        );
-        const onWillStopSessionDisposable = tracker.onWillStopSession(
-            async (session) => await this.handleOnWillStopSession(session)
-        );
-        const onDidChangeActiveStackItemDisposable = tracker.onDidChangeActiveStackItem(
-            async (stackFrame) => await this.handleOnDidChangeActiveStackItem(stackFrame)
-        );
-        // Extracts out data from objects inside of the scvd model
-        if (!this._scvdModel) {
-            console.warn('No SCVD model set in ComponentViewerTreeDataProvider');
-            return;
-        }
-            */
-        this.addRootObject();
+        await this.addRootObject();
         this.refresh();
     }
 
@@ -78,6 +57,7 @@ export class ComponentViewerTreeDataProvider implements vscode.TreeDataProvider<
         // Needs fixing, getGuiValue() for ScvdNode returns 0 when undefined
         treeItem.description = element.getGuiValue() ?? '';
         treeItem.tooltip = element.getGuiLineInfo() ?? '';
+        treeItem.id = (element as unknown as { nodeId: string }).nodeId;
         return treeItem;
     }
 
@@ -86,31 +66,17 @@ export class ComponentViewerTreeDataProvider implements vscode.TreeDataProvider<
             return Promise.resolve(this._objectOutRoots);
         }
 
-        return Promise.resolve(element.getGuiChildren() || []);
+        const children = element.getGuiChildren() || [];
+        return Promise.resolve(children);
     }
-    /*
-    private async handleOnDidChangeActiveDebugSession(session: GDBTargetDebugSession | undefined): Promise<void> {
-        // Handle changes to the active debug session if needed
-        this.refresh();
-    }
-
-    private async handleOnWillStartSession(session: GDBTargetDebugSession): Promise<void> {
-        // Handle actions before a debug session starts if needed
-        this.refresh();
-    }
-
-    private async handleOnWillStopSession(session: GDBTargetDebugSession): Promise<void> {
-        // Handle actions before a debug session stops if needed
-        this.refresh();
-    }
-
-    private async handleOnDidChangeActiveStackItem(stackFrame: SessionStackItem): Promise<void> {
-        // Handle changes to the active stack frame if needed
-        this.refresh();
-    }
-    */
+    
     private refresh(): void {
         this._onDidChangeTreeData.fire();
+    }
+
+    public resetModelCache(): void {
+        this._scvdModel.scvdGuiOut = [];
+        this._objectOutRoots = [];
     }
 
     public async addGuiOut(guiOut: ScvdGuiInterface[] | undefined) {
@@ -134,8 +100,6 @@ export class ComponentViewerTreeDataProvider implements vscode.TreeDataProvider<
         if (this._scvdModel?.scvdGuiOut.length === 0) {
             return;
         }
-        this._scvdModel.scvdGuiOut.forEach(guiOut => {
-            this._objectOutRoots.push(guiOut);
-        });
+        this._objectOutRoots = [...this._scvdModel.scvdGuiOut];
     }
 }

--- a/src/views/component-viewer/scvd-gui-tree.ts
+++ b/src/views/component-viewer/scvd-gui-tree.ts
@@ -27,13 +27,13 @@ export class ScvdGuiTree implements ScvdGuiInterface {
 
     constructor(
         parent: ScvdGuiTree | undefined,
+        nodeId?: string,
     ) {
         this._parent = parent;
         if (parent) {
             parent.addChild(this);
         }
-        this._nodeId = ScvdGuiTree.idCnt.toString();
-        ScvdGuiTree.idCnt++;
+        this._nodeId = nodeId ?? `${this.classname}_${ScvdGuiTree.idCnt++}`;
     }
 
     public get parent(): ScvdGuiTree | undefined {
@@ -45,7 +45,7 @@ export class ScvdGuiTree implements ScvdGuiInterface {
     }
 
     public get nodeId(): string {
-        return this.classname + '_' + this._nodeId.toString();
+        return this._nodeId;
     }
 
     public clear(): void {

--- a/src/views/component-viewer/statement-engine/statement-item.ts
+++ b/src/views/component-viewer/statement-engine/statement-item.ts
@@ -37,7 +37,7 @@ export class StatementItem extends StatementBase {
         const guiName = await this.scvdItem.getGuiName();
 
         //const childGuiTree = (guiName?.length) ? new ScvdGuiTree(guiTree) : guiTree;
-        const childGuiTree = new ScvdGuiTree(guiTree);
+        const childGuiTree = new ScvdGuiTree(guiTree, this.scvdItem.nodeId);
 
         //if (guiName?.length) {   // else nothing to execute
         const guiValue = await this.scvdItem.getGuiValue();

--- a/src/views/component-viewer/statement-engine/statement-out.ts
+++ b/src/views/component-viewer/statement-engine/statement-out.ts
@@ -33,7 +33,7 @@ export class StatementOut extends StatementBase {
             return;
         }
 
-        const childGuiTree = new ScvdGuiTree(guiTree);
+        const childGuiTree = new ScvdGuiTree(guiTree, this.scvdItem.nodeId);
         await this.onExecute(executionContext, childGuiTree);
 
         if (this.children.length > 0) {

--- a/src/views/component-viewer/statement-engine/statement-print.ts
+++ b/src/views/component-viewer/statement-engine/statement-print.ts
@@ -33,7 +33,7 @@ export class StatementPrint extends StatementBase {
             return;
         }
 
-        const childGuiTree = new ScvdGuiTree(guiTree);
+        const childGuiTree = new ScvdGuiTree(guiTree, this.scvdItem.nodeId);
         const guiName = await this.scvdItem.getGuiName();
         const guiValue = await this.scvdItem.getGuiValue();
         childGuiTree.setGuiName(guiName);


### PR DESCRIPTION
GUI collapses all of the variables with every step refresh. That is now fixed by maintaining the GUI Tree instead of deleting it and rebuilding it