### PR TITLE
evaluate readMem issues on STOP, STEP

### DIFF
--- a/src/views/component-viewer/component-viewer-main.ts
+++ b/src/views/component-viewer/component-viewer-main.ts
@@ -75,7 +75,7 @@ export class ComponentViewer {
         await this.readScvdFiles(tracker, session);
         // Are there any SCVD files found in cbuild-run?
         if (this._instances.length > 0) {
-            await this.updateInstances();
+            // await this.updateInstances();
             return;
         }
     }
@@ -93,8 +93,8 @@ export class ComponentViewer {
         const onDidChangeActiveDebugSessionDisposable = tracker.onDidChangeActiveDebugSession(async (session) => {
             await this.handleOnDidChangeActiveDebugSession(session);
         });
-        const onStopped = tracker.onStopped(async (session) => {
-            await this.handleOnStopped(session.session);
+        const onStackTrace = tracker.onStackTrace(async (session) => {
+            await this.handleOnStackTrace(session.session);
         });
         // clear all disposables on extension deactivation
         context.subscriptions.push(
@@ -102,11 +102,11 @@ export class ComponentViewer {
             onConnectedDisposable,
             onDidChangeActiveStackItemDisposable,
             onDidChangeActiveDebugSessionDisposable,
-            onStopped
+            onStackTrace
         );
     }
 
-    private async handleOnStopped(session: GDBTargetDebugSession): Promise<void> {
+    private async handleOnStackTrace(session: GDBTargetDebugSession): Promise<void> {
         // Clear active session if it is NOT the one being stopped
         if (this._activeSession?.session.id !== session.session.id) {
             this._activeSession = undefined;
@@ -121,7 +121,7 @@ export class ComponentViewer {
             this._activeSession = undefined;
         }
         // Update component viewer instance(s)
-        await this.updateInstances();
+        //await this.updateInstances();
     }
 
     private async handleOnConnected(session: GDBTargetDebugSession, tracker: GDBTargetDebugTracker): Promise<void> {
@@ -146,7 +146,7 @@ export class ComponentViewer {
     private async handleOnDidChangeActiveStackItem(stackTraceItem: SessionStackItem): Promise<void> {
         if ((stackTraceItem.item as vscode.DebugStackFrame).frameId !== undefined) {
             // Update instance(s) with new stack frame info
-            await this.updateInstances();
+            //await this.updateInstances();
         }
     }
 

--- a/src/views/component-viewer/component-viewer-target-access.ts
+++ b/src/views/component-viewer/component-viewer-target-access.ts
@@ -42,6 +42,9 @@ export class ComponentViewerTargetAccess {
                 context: context
             };
             const response = await this._activeSession?.session.customRequest('evaluate', args) as DebugProtocol.EvaluateResponse['body'];
+            if (response.result.startsWith('Error')) { //cdt-adapter returns 'Error' string without throwing error response
+                return undefined;
+            }
             return response.result.split(' ')[0]; // Return only the address part
         } catch (error: unknown) {
             const errorMessage = (error as Error)?.message;


### PR DESCRIPTION
## Fixes
Branch to evaluate readMem issues on STOP, STEP where backend seems to return 0 on first read (which in RTX5.scvd checks if there is an RTX5).

## Changes
-

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

