### PR TITLE
Bump lodash to v4.17.21

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,9 +5414,9 @@ lodash.truncate@^4.4.2:
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/dependabot/24

## Changes
<!-- List the changes this PR introduces -->

- Bumps lodash to 4.17.21 (transient dependency of vsce).

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

