### PR TITLE
Remove 'always-auth' setting from setup-node action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Set version
@@ -189,7 +188,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Download dist
@@ -248,7 +246,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Set version
@@ -148,7 +147,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Download dist
@@ -209,7 +207,6 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           node-version: '20'
           registry-url: https://npm.pkg.github.com
-          always-auth: true
           package-manager-cache: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

Setting causes loads of ugly warning annotations

<img width="467" height="330" alt="image" src="https://github.com/user-attachments/assets/85709c34-4989-49e5-b601-cae4446013ea" />

## Changes
<!-- List the changes this PR introduces -->

- Removed `always-auth` setting from setup-node action. Deprecated and soon to be removed. As I understand, it is no longer needed for modern NPM versions.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

