### PR TITLE
Remove undocumented core registers from Component Viewer

### DIFF
--- a/src/views/component-viewer/scvd-debug-target.ts
+++ b/src/views/component-viewer/scvd-debug-target.ts
@@ -35,7 +35,6 @@ const REGISTER_GDB_ENTRIES: Array<[string, string]> = [
     // Armv8-M Secure/Non-secure additions
     ['MSP_NS', 'msp_ns'], ['PSP_NS', 'psp_ns'], ['MSP_S', 'msp_s'], ['PSP_S', 'psp_s'],
     ['MSPLIM_S', 'msplim_s'], ['PSPLIM_S', 'psplim_s'], ['MSPLIM_NS', 'msplim_ns'], ['PSPLIM_NS', 'psplim_ns'],
-    ['SYSREGS_S', 'sysregs_s'], ['SYSREGS_NS', 'sysregs_ns'], ['SECURITY', 'security'],
     ['PRIMASK_S', 'primask_s'], ['BASEPRI_S', 'basepri_s'], ['FAULTMASK_S', 'faultmask_s'], ['CONTROL_S', 'control_s'],
     ['PRIMASK_NS', 'primask_ns'], ['BASEPRI_NS', 'basepri_ns'], ['FAULTMASK_NS', 'faultmask_ns'], ['CONTROL_NS', 'control_ns'],
 ];


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- N/A

## Changes
<!-- List the changes this PR introduces -->

- Reviewed core register definitions implemented in Component Viewer and removed three that are not documented and highly unlikely to be used in SCVD files yet:
  - SYSREGS_S / SYSREGS_NS: Both are effectively unions of PRIMASK_x, BASEPRI_x, FAULTMASK_x, CONTROL_x. Means information is not lost.
  - SECURITY: Not an architecturally defined register. But was a uVision internal "virtual" register showing states determined by looking at various memory mapped SCB registers.

All three are unsupported by GDB. Adding them should be revisited as part of #239 and/or #736 .

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

