### PR TITLE
Swap default order of Live Watch and Component Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,13 +57,13 @@
     "views": {
       "cmsis-debugger": [
         {
-          "id": "cmsis-debugger.componentViewer",
-          "name": "Component Viewer",
+          "id": "cmsis-debugger.liveWatch",
+          "name": "Live Watch",
           "icon": "media/trace-and-live-light.svg"
         },
         {
-          "id": "cmsis-debugger.liveWatch",
-          "name": "Live Watch",
+          "id": "cmsis-debugger.componentViewer",
+          "name": "Component Viewer",
           "icon": "media/trace-and-live-light.svg"
         }
       ]


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

Realized that the default order of Live Watch and Component Viewer got swapped by swapping entries in package.json. Was convinced it wasn't when I got asked about this before. 😒 

## Changes
<!-- List the changes this PR introduces -->

- Swap the order

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

New default order

<img width="512" height="780" alt="image" src="https://github.com/user-attachments/assets/0cf84670-2e44-445b-8caf-78ad6cea3357" />


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

