### PR TITLE
Updated version calulation algo when no build info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,13 @@ jobs:
               ;;
             pull_request)
               DESCRIBE=$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
-              QUALIFIER=$(git describe --tags | grep -Eo '\-g[0-9a-f]+$')
+              QUALIFIER=$(git describe --tags | grep -Eo '\-g[0-9a-f]+$' || true)
               yarn version -s --no-git-tag-version --new-version "${DESCRIBE#v}"
               yarn version --no-git-tag-version --prepatch --preid "pr${{ github.event.number }}${QUALIFIER}"
               ;;
             *)
               DESCRIBE=$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
-              QUALIFIER=$(git describe --tags | grep -Eo '[0-9]+\-g[0-9a-f]+$')
+              QUALIFIER=$(git describe --tags | grep -Eo '[0-9]+\-g[0-9a-f]+$' || true)
               yarn version -s --no-git-tag-version --new-version "${DESCRIBE#v}"
               yarn version --no-git-tag-version --prepatch --preid "${{ github.ref_name }}${QUALIFIER}"
               ;;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
         if: runner.os == 'Linux' && github.repository_owner == 'Open-CMSIS-Pack'
         run: |
           DESCRIBE=$(git describe --tags | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
-          QUALIFIER=$(git describe --tags | grep -Eo '[0-9]+\-g[0-9a-f]+$')
+          QUALIFIER=$(git describe --tags | grep -Eo '[0-9]+\-g[0-9a-f]+$' || true)
           BRANCH=$(echo "${{ github.ref_name }}" | sed 's/[^0-9A-Za-z-]/-/g')
           yarn version -s --no-git-tag-version --new-version "${DESCRIBE#v}"
           yarn version -s --no-git-tag-version --prepatch --preid "${BRANCH}${QUALIFIER:+-${QUALIFIER}}"


### PR DESCRIPTION
## Changes
- If we are ahead of a tag, extract how many commits ahead we are and the short commit hash. `Otherwise, leave it empty`
- When `grep` finds nothing, it exits with error code 1. Without` || true`, the whole script might fail (especially in CI with set -e).

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

