### PR TITLE
Updated @types/node to version 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -484,7 +484,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^30.0.0",
     "@types/minimist": "^1.2.5",
-    "@types/node": "^22.0.0",
+    "@types/node": "^22.19.15",
     "@types/node-fetch": "^2.6.13",
     "@types/vscode": "^1.108.1",
     "@types/xml2js": "^0.4.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,7 +1995,7 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@^22.0.0":
+"@types/node@^22.19.15":
   version "22.19.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.15.tgz#6091d99fdf7c08cb57dc8b1345d407ba9a1df576"
   integrity sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==


### PR DESCRIPTION
## Changes
- As a part of the migration to Node 22, `@types/node `needed to be moved as well.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

