### PR TITLE
Remove cmsis-debugger.corePeripherals.enabled guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
         {
           "id": "cmsis-debugger.corePeripherals",
           "name": "Core Peripherals",
-          "icon": "media/trace-and-live-light.svg",
-          "when": "config.cmsis-debugger.corePeripherals.enabled"
+          "icon": "media/trace-and-live-light.svg"
         }
       ]
     },
@@ -194,48 +193,41 @@
         "command": "vscode-cmsis-debugger.corePeripherals.lockComponent",
         "title": "Lock Component",
         "icon": "$(unlock)",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.unlockComponent",
         "title": "Unlock Component",
         "icon": "$(lock)",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.enablePeriodicUpdate",
         "title": "Enable Periodic Update",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.disablePeriodicUpdate",
         "title": "Disable Periodic Update",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.expandAll",
         "title": "Expand All",
         "icon": "$(expand-all)",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.filterTree",
         "title": "Filter Tree",
         "icon": "$(filter)",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       },
       {
         "command": "vscode-cmsis-debugger.corePeripherals.clearFilter",
         "title": "Clear Filter",
         "icon": "$(clear-all)",
-        "category": "Core Peripherals",
-        "when": "config.cmsis-debugger.corePeripherals.enabled"
+        "category": "Core Peripherals"
       }
     ],
     "menus": {
@@ -412,7 +404,7 @@
         },
         {
           "command": "vscode-cmsis-debugger.corePeripherals.expandAll",
-          "when": "config.cmsis-debugger.corePeripherals.enabled && view == cmsis-debugger.corePeripherals",
+          "when": "view == cmsis-debugger.corePeripherals",
           "group": "navigation@3"
         },
         {
@@ -427,12 +419,12 @@
         },
         {
           "command": "vscode-cmsis-debugger.corePeripherals.filterTree",
-          "when": "config.cmsis-debugger.corePeripherals.enabled && view == cmsis-debugger.corePeripherals",
+          "when": "view == cmsis-debugger.corePeripherals",
           "group": "navigation@1"
         },
         {
           "command": "vscode-cmsis-debugger.corePeripherals.clearFilter",
-          "when": "config.cmsis-debugger.corePeripherals.enabled && view == cmsis-debugger.corePeripherals && corePeripherals.filterActive",
+          "when": "view == cmsis-debugger.corePeripherals && corePeripherals.filterActive",
           "group": "navigation@2"
         }
       ],
@@ -494,12 +486,12 @@
         },
         {
           "command": "vscode-cmsis-debugger.corePeripherals.lockComponent",
-          "when": "config.cmsis-debugger.corePeripherals.enabled && view == cmsis-debugger.corePeripherals && viewItem == parentInstance",
+          "when": "view == cmsis-debugger.corePeripherals && viewItem == parentInstance",
           "group": "inline@1"
         },
         {
           "command": "vscode-cmsis-debugger.corePeripherals.unlockComponent",
-          "when": "config.cmsis-debugger.corePeripherals.enabled && view == cmsis-debugger.corePeripherals && viewItem == locked.parentInstance",
+          "when": "view == cmsis-debugger.corePeripherals && viewItem == locked.parentInstance",
           "group": "inline@2"
         }
       ]

--- a/src/desktop/extension.test.ts
+++ b/src/desktop/extension.test.ts
@@ -28,11 +28,6 @@ describe('extension', () => {
         const componentViewerCommands = [ 'cmsis-debugger.componentViewer.open', 'cmsis-debugger.componentViewer.focus' ];
         const corePeripheralsCommands = [ 'cmsis-debugger.corePeripherals.open', 'cmsis-debugger.corePeripherals.focus' ];
 
-        beforeEach(() => {
-            // Temporary mock for config.cmsis-debugger.corePeripherals.enabled until removed again
-            (vscode.workspace.getConfiguration as jest.Mock).mockReturnValueOnce({ get: (command: string) => command === 'cmsis-debugger.corePeripherals.enabled' });
-        });
-
         it('activates extension without asking to reload', async () => {
             const loggerSpy = jest.spyOn(logger, 'debug');
             await activate(extensionContextFactory());

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -79,11 +79,9 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
     if (!await componentViewer.activate(gdbtargetDebugTracker)) {
         canCompleteActivation = false;
     }
-    // Temporary guard: enable once solution is ready
-    const corePeripheralsEnabled = vscode.workspace.getConfiguration().get<boolean>('cmsis-debugger.corePeripherals.enabled', false);
     // Core Peripherals
     logger.debug('Activating Core Peripherals');
-    if (corePeripheralsEnabled && !await corePeripherals.activate(gdbtargetDebugTracker)) {
+    if (!await corePeripherals.activate(gdbtargetDebugTracker)) {
         canCompleteActivation = false;
     }
 


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

N/A

## Changes
<!-- List the changes this PR introduces -->

- Removes need to set `cmsis-debugger.corePeripherals.enabled` in `settings.json`. Stable enough to be always on for pre-release.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

