### PR TITLE
fix: ensure optional deps are installed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm ci --prefer-offline --include=optional
+        run: npm install --prefer-offline --include=optional --no-audit --no-fund
 
       - name: Build on Windows or macOS
         if: runner.os != 'Linux'
@@ -214,7 +214,7 @@ jobs:
 
       - name: Download tools
         run: |
-          npm ci --prefer-offline --include=optional
+          npm install --prefer-offline --include=optional --no-audit --no-fund
           npm run download-tools -- --target ${{ matrix.target }} --no-cache
 
       - name: Create vsix package
@@ -268,7 +268,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --include=optional
+        run: npm install --prefer-offline --include=optional --no-audit --no-fund
 
       - name: Download vsix package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm ci
+        run: npm ci --prefer-offline --include=optional
 
       - name: Build on Windows or macOS
         if: runner.os != 'Linux'
@@ -214,7 +214,7 @@ jobs:
 
       - name: Download tools
         run: |
-          npm ci
+          npm ci --prefer-offline --include=optional
           npm run download-tools -- --target ${{ matrix.target }} --no-cache
 
       - name: Create vsix package
@@ -268,7 +268,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --include=optional
 
       - name: Download vsix package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm install --prefer-offline --include=optional --no-audit --no-fund
+        run: npm install --prefer-offline --no-audit --no-fund --include=optional
 
       - name: Build on Windows or macOS
         if: runner.os != 'Linux'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Initialize CodeQL
         id: initialize
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           queries: security-extended 
           languages: TypeScript
@@ -59,8 +59,8 @@ jobs:
           
       - name: Autobuild
         id: autobuild
-        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm ci --prefer-offline --include=optional
+        run: npm install --prefer-offline --include=optional --no-audit --no-fund
 
       - name: Build on Windows or macOS
         if: runner.os != 'Linux'
@@ -183,7 +183,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm ci --prefer-offline --include=optional
+          npm install --prefer-offline --include=optional --no-audit --no-fund
           npm run download-tools:nightly -- --target ${{ matrix.target }} --no-cache
 
       - name: Create vsix package
@@ -237,7 +237,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --include=optional
+        run: npm install --prefer-offline --include=optional --no-audit --no-fund
 
       - name: Download vsix package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npm ci
+        run: npm ci --prefer-offline --include=optional
 
       - name: Build on Windows or macOS
         if: runner.os != 'Linux'
@@ -183,7 +183,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm ci
+          npm ci --prefer-offline --include=optional
           npm run download-tools:nightly -- --target ${{ matrix.target }} --no-cache
 
       - name: Create vsix package
@@ -237,7 +237,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --include=optional
 
       - name: Download vsix package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -80,6 +80,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -49,7 +49,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --include=optional
 
       - name: Generate third-party licenses report
         run: npm run tpip:report

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -49,7 +49,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --include=optional
+        run: npm install --prefer-offline --include=optional --no-audit --no-fund
 
       - name: Generate third-party licenses report
         run: npm run tpip:report


### PR DESCRIPTION
## Changes
Add `--prefer-offline --include=optional` to all npm ci calls.

- --prefer-offline: use cached packages where available, reducing network usage on CI runners.
- --include=optional: ensure platform-specific esbuild binaries (e.g. @esbuild/linux-x64, @esbuild/darwin-arm64) are installed.
- --no-fund: Disables messages about funding/supporting packages

These are required by tsx, which is used to run TypeScript scripts such as copyright:check, download-tools, and check:links.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

