### PR TITLE
Migrate markdown link checks action to local npm script

### DIFF
--- a/.github/markdown-link-check.jsonc
+++ b/.github/markdown-link-check.jsonc
@@ -11,6 +11,6 @@
   ],
   "ignorePatterns": [
     { "pattern": "^#" },
-    { "pattern": "https://www\\.st\\.com/en/development-tools/hardware-debugger-and-programmer-tools-for-stm32/products\\.html" }
+    { "pattern": "^https://developer\\.arm\\.com/" }
   ]
 }

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -45,6 +45,8 @@ jobs:
   check-links:
     name: Check Markdown Links
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -53,9 +55,18 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Check Links
-        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          use-quiet-mode: 'no'
-          use-verbose-mode: 'yes'
-          config-file: '.github/markdown-link-check.jsonc'
+          node-version-file: package.json
+          registry-url: https://npm.pkg.github.com
+          package-manager-cache: false
+
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm ci
+
+      - name: Check Links
+        run: npm run check:links

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,24 +13,6 @@ permissions:
   contents: read
 
 jobs:
-  check-links:
-    name: Check Markdown Links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Check Links
-        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
-        with:
-          use-quiet-mode: 'no'
-          use-verbose-mode: 'yes'
-          config-file: '.github/markdown-link-check.jsonc'
-
   build:
     if: github.repository == 'Open-CMSIS-Pack/vscode-cmsis-debugger'
     strategy:
@@ -102,7 +84,12 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run build
 
+      - name: Check Links
+        if: runner.os == 'Linux'
+        run: npm run check:links
+
       - name: Check copyright
+        if: runner.os == 'Linux'
         run: npm run copyright:check
 
       - name: Test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,41 @@
-# Open-CMSIS-Pack Security Policy  
+# Open-CMSIS-Pack Security Policy
 
-This document outlines the security procedures and policies for the Open-CMSIS-Pack vscode-cmsis-debugger project.  
+This document outlines the security procedures and policies for the Open-CMSIS-Pack vscode-cmsis-debugger project.
 
-## Table of Contents  
+## Table of Contents
 
-- [Reporting a Security Issue](#reporting-a-security-issue)  
-- [Vulnerability Management](#vulnerability-management)  
-- [Improving This Policy](#improving-this-policy)  
+- [Reporting a Security Issue](#reporting-a-security-issue)
+- [Vulnerability Management](#vulnerability-management)
+- [Improving This Policy](#improving-this-policy)
 
-## Reporting a Security Issue  
+## Reporting a Security Issue
 
 The Open-CMSIS-Pack vscode-cmsis-debugger maintainers take security issues seriously and appreciate responsible
-disclosure. Your efforts to improve project security are highly valued.  
+disclosure. Your efforts to improve project security are highly valued.
 
 We use GitHub's [private vulnerability reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
 guidelines.
 To report a security issue, please click on
 [Report a vulnerability](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/security/advisories/new) and
-include:  
+include:
 
-- A detailed description of the issue  
-- Steps to reproduce the vulnerability  
-- Affected project versions  
-- Any known mitigations  
+- A detailed description of the issue
+- Steps to reproduce the vulnerability
+- Affected project versions
+- Any known mitigations
 
 A maintainer will acknowledge your report as soon as possible and guide the next steps. We will keep you informed of
-progress toward a fix and may request additional details if needed.  
+progress toward a fix and may request additional details if needed.
 
-## Vulnerability Management  
+## Vulnerability Management
 
-Once a security issue is reported, the maintainers will:  
+Once a security issue is reported, the maintainers will:
 
-1. Confirm the issue  
-2. Identify/Confirm affected versions  
-3. Audit related code for similar vulnerabilities  
-4. Develop and release patches for maintained versions  
+1. Confirm the issue
+2. Identify/Confirm affected versions
+3. Audit related code for similar vulnerabilities
+4. Develop and release patches for maintained versions
 
-## Improving This Policy  
+## Improving This Policy
 
 If you have suggestions for improving this process, please open an issue or submit a pull request.


### PR DESCRIPTION
## Changes
* Updated the Markdown workflow to use `npm run check:links` instead of a separate action, as the current action is unreliable and [fails to detect broken links](https://github.com/tcort/markdown-link-check/issues/553)
* Applied the same changes to the Nightly workflow.
* Restricted link and copyright checks to the Linux runner, since running them across all operating systems produces the same results.
* Updated the ignore pattern with `developer.arm.com` as CI request never completes the EULA acceptance flow.


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

