### PR TITLE
adding commands to change output radix to Live Watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -490,12 +490,12 @@
         },
         {
           "command": "cdt.debug.setOutputRadixToDecimal",
-          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix != 'decimal' && (debugType == gdb || debugType == gdbtarget)",
+          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix && cdt.debug.outputRadix != 'decimal' && (debugType == 'gdb' || debugType == 'gdbtarget')",
           "group": "contextMenuG4@1"
         },
         {
           "command": "cdt.debug.setOutputRadixToHex",
-          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix != 'hexadecimal' && (debugType == gdb || debugType == gdbtarget)",
+          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix && cdt.debug.outputRadix != 'hexadecimal' && (debugType == 'gdb' || debugType == 'gdbtarget')",
           "group": "contextMenuG4@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -489,6 +489,16 @@
           "group": "contextMenuG3@1"
         },
         {
+          "command": "cdt.debug.setOutputRadixToDecimal",
+          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix != 'decimal' && (debugType == gdb || debugType == gdbtarget)",
+          "group": "contextMenuG4@1"
+        },
+        {
+          "command": "cdt.debug.setOutputRadixToHex",
+          "when": "(view == cmsis-debugger.liveWatch) && inDebugMode && cdt.debug.outputRadix != 'hexadecimal' && (debugType == gdb || debugType == gdbtarget)",
+          "group": "contextMenuG4@2"
+        },
+        {
           "command": "vscode-cmsis-debugger.componentViewer.lockComponent",
           "when": "view == cmsis-debugger.componentViewer && viewItem == parentInstance",
           "group": "inline@1"


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#975 ](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/975)

## Changes
<!-- List the changes this PR introduces -->

- I basically added the command provided in the PR https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/217 to the Live Watch

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
<img width="441" height="368" alt="Screenshot 2026-05-12 at 12 49 33" src="https://github.com/user-attachments/assets/778cb38d-5217-4c68-b9ac-a866e63a67cd" />
<img width="425" height="361" alt="Screenshot 2026-05-12 at 12 49 15" src="https://github.com/user-attachments/assets/57befdae-74bf-4d22-ad0d-571712427faa" />


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

