### PR TITLE
[CI]: Retry Markdown link checks

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -69,7 +69,7 @@ jobs:
         run: npm ci
 
       # Automatically retry the link check if it fails
-      # This helps reduce false negatives in CI caused by transient errors
+      # This helps reduce false positives in CI caused by transient errors
       - name: Check Links
         if: runner.os == 'Linux'
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -68,5 +68,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm ci
 
+      # Automatically retry the link check if it fails
+      # This helps reduce false negatives in CI caused by transient errors
       - name: Check Links
-        run: npm run check:links
+        if: runner.os == 'Linux'
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        with:
+          attempt_delay: 2000
+          attempt_limit: 3
+          command: npm run check:links

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,7 +85,7 @@ jobs:
         run: npm run build
 
       # Automatically retry the link check if it fails
-      # This helps reduce false negatives in CI caused by transient errors
+      # This helps reduce false positives in CI caused by transient errors
       - name: Check Links
         if: runner.os == 'Linux'
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,9 +84,15 @@ jobs:
         if: runner.os == 'Linux'
         run: npm run build
 
+      # Automatically retry the link check if it fails
+      # This helps reduce false negatives in CI caused by transient errors
       - name: Check Links
         if: runner.os == 'Linux'
-        run: npm run check:links
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        with:
+          attempt_delay: 2000
+          attempt_limit: 3
+          command: npm run check:links
 
       - name: Check copyright
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Fixes
- #994 

## Changes

- Added retry logic to the markdown link check job to reduce false positives caused by transient network issues.
- The action now retries failed link checks up to 3 times with a 2-second interval between attempts.
- If the check still fails after all retries, the link(s) is reported as problematic.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

