### PR TITLE
updating all views on receiving invalidated or memory events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cmsis-debugger",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cmsis-debugger",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-uri": "^3.1.0",

--- a/src/debug-session/__test__/debug-session.factory.ts
+++ b/src/debug-session/__test__/debug-session.factory.ts
@@ -15,9 +15,15 @@
  */
 // generated with AI
 
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import { GDBTargetDebugSession, GDBTargetDebugTracker, TargetState } from '..';
 
 export type OnRefreshCallback = (session: Session) => void;
+
+export type TestMemoryEvent = {
+    session: Session;
+    event: DebugProtocol.MemoryEvent;
+};
 
 export type Session = {
     session: { id: string };
@@ -35,7 +41,7 @@ export type TrackerCallbacks = {
     onStackTrace: (cb: (session: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     onDidChangeActiveStackItem: (cb: (session: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     onWillStartSession: (cb: (session: Session) => Promise<void>) => { dispose: jest.Mock };
-    onMemory: (cb: (event: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
+    onMemory: (cb: (event: TestMemoryEvent) => Promise<void>) => { dispose: jest.Mock };
     callbacks: Partial<{
         willStop: (session: Session) => Promise<void>;
         connected: (session: Session) => Promise<void>;
@@ -43,7 +49,7 @@ export type TrackerCallbacks = {
         stackTrace: (session: { session: Session }) => Promise<void>;
         activeStackItem: (session: { session: Session }) => Promise<void>;
         willStart: (session: Session) => Promise<void>;
-        memory: (event: { session: Session }) => Promise<void>;
+        memory: (event: TestMemoryEvent) => Promise<void>;
     }>;
 };
 

--- a/src/debug-session/__test__/debug-session.factory.ts
+++ b/src/debug-session/__test__/debug-session.factory.ts
@@ -25,6 +25,11 @@ export type TestMemoryEvent = {
     event: DebugProtocol.MemoryEvent;
 };
 
+export type TestInvalidatedEvent = {
+    session: Session;
+    event: DebugProtocol.InvalidatedEvent;
+};
+
 export type Session = {
     session: { id: string };
     getCbuildRun: () => Promise<{ getScvdFilePaths: () => string[] } | undefined>;
@@ -42,6 +47,7 @@ export type TrackerCallbacks = {
     onDidChangeActiveStackItem: (cb: (session: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     onWillStartSession: (cb: (session: Session) => Promise<void>) => { dispose: jest.Mock };
     onMemory: (cb: (event: TestMemoryEvent) => Promise<void>) => { dispose: jest.Mock };
+    onInvalidated: (cb: (event: TestInvalidatedEvent) => Promise<void>) => { dispose: jest.Mock };
     callbacks: Partial<{
         willStop: (session: Session) => Promise<void>;
         connected: (session: Session) => Promise<void>;
@@ -50,6 +56,7 @@ export type TrackerCallbacks = {
         activeStackItem: (session: { session: Session }) => Promise<void>;
         willStart: (session: Session) => Promise<void>;
         memory: (event: TestMemoryEvent) => Promise<void>;
+        invalidated: (event: TestInvalidatedEvent) => Promise<void>;
     }>;
 };
 
@@ -83,6 +90,10 @@ export const trackerFactory = (): TrackerCallbacks => {
         },
         onMemory: (cb) => {
             callbacks.memory = cb;
+            return { dispose: jest.fn() };
+        },
+        onInvalidated: (cb) => {
+            callbacks.invalidated = cb;
             return { dispose: jest.fn() };
         },
     };

--- a/src/debug-session/__test__/debug-session.factory.ts
+++ b/src/debug-session/__test__/debug-session.factory.ts
@@ -35,6 +35,7 @@ export type TrackerCallbacks = {
     onStackTrace: (cb: (session: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     onDidChangeActiveStackItem: (cb: (session: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     onWillStartSession: (cb: (session: Session) => Promise<void>) => { dispose: jest.Mock };
+    onMemory: (cb: (event: { session: Session }) => Promise<void>) => { dispose: jest.Mock };
     callbacks: Partial<{
         willStop: (session: Session) => Promise<void>;
         connected: (session: Session) => Promise<void>;
@@ -42,6 +43,7 @@ export type TrackerCallbacks = {
         stackTrace: (session: { session: Session }) => Promise<void>;
         activeStackItem: (session: { session: Session }) => Promise<void>;
         willStart: (session: Session) => Promise<void>;
+        memory: (event: { session: Session }) => Promise<void>;
     }>;
 };
 
@@ -71,6 +73,10 @@ export const trackerFactory = (): TrackerCallbacks => {
         },
         onWillStartSession: (cb) => {
             callbacks.willStart = cb;
+            return { dispose: jest.fn() };
+        },
+        onMemory: (cb) => {
+            callbacks.memory = cb;
             return { dispose: jest.fn() };
         },
     };

--- a/src/debug-session/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.test.ts
@@ -20,7 +20,8 @@ import {
     GDBTargetDebugTracker,
     SessionStackItem,
     SessionStackTrace,
-    StoppedEvent
+    StoppedEvent,
+    MemoryEvent
 } from './gdbtarget-debug-tracker';
 import { debugSessionFactory, extensionContextFactory } from '../__test__/vscode.factory';
 import { GDBTargetDebugSession } from './gdbtarget-debug-session';
@@ -221,6 +222,51 @@ describe('GDBTargetDebugTracker', () => {
             expect(result).toBeDefined();
             expect(result!.session).toEqual(gdbSession);
             expect(result!.event).toEqual(continuedEvent);
+        });
+
+        it('sends a session memory event', async () => {
+            let gdbSession: GDBTargetDebugSession|undefined = undefined;
+            debugTracker.onWillStartSession(session => gdbSession = session);
+            let result: MemoryEvent|undefined = undefined;
+            debugTracker.onMemory(event => result = event);
+            const tracker = await adapterFactory!.createDebugAdapterTracker(debugSessionFactory(debugConfigurationFactory()));
+            tracker!.onWillStartSession!();
+            const memoryEvent: DebugProtocol.MemoryEvent = {
+                event: 'memory',
+                type: 'event',
+                seq: 1,
+                body: {
+                    memoryReference: '0x1234',
+                    offset: 0,
+                    count: 4
+                }
+            };
+            tracker!.onDidSendMessage!(memoryEvent);
+            expect(gdbSession).toBeDefined();
+            expect(result).toBeDefined();
+            expect(result!.session).toEqual(gdbSession);
+            expect(result!.event).toEqual(memoryEvent);
+        });
+
+        it('sends a stack trace event on receiving an invalidated event', async () => {
+            let gdbSession: GDBTargetDebugSession|undefined = undefined;
+            debugTracker.onWillStartSession(session => gdbSession = session);
+            let result: SessionStackTrace|undefined = undefined;
+            debugTracker.onStackTrace(event => result = event);
+            const tracker = await adapterFactory!.createDebugAdapterTracker(debugSessionFactory(debugConfigurationFactory()));
+            tracker!.onWillStartSession!();
+            const invalidatedEvent: DebugProtocol.InvalidatedEvent = {
+                event: 'invalidated',
+                type: 'event',
+                seq: 1,
+                body: {
+                    areas: ['stack']
+                }
+            };
+            tracker!.onDidSendMessage!(invalidatedEvent);
+            expect(gdbSession).toBeDefined();
+            expect(result).toBeDefined();
+            expect(result!.session).toEqual(gdbSession);
         });
 
         it('sends a session stopped event', async () => {

--- a/src/debug-session/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.test.ts
@@ -21,7 +21,8 @@ import {
     SessionStackItem,
     SessionStackTrace,
     StoppedEvent,
-    MemoryEvent
+    MemoryEvent,
+    InvalidatedEvent
 } from './gdbtarget-debug-tracker';
 import { debugSessionFactory, extensionContextFactory } from '../__test__/vscode.factory';
 import { GDBTargetDebugSession } from './gdbtarget-debug-session';
@@ -248,11 +249,11 @@ describe('GDBTargetDebugTracker', () => {
             expect(result!.event).toEqual(memoryEvent);
         });
 
-        it('sends a stack trace event on receiving an invalidated event', async () => {
+        it('sends an Invalidated event on receiving an invalidated event', async () => {
             let gdbSession: GDBTargetDebugSession|undefined = undefined;
             debugTracker.onWillStartSession(session => gdbSession = session);
-            let result: SessionStackTrace|undefined = undefined;
-            debugTracker.onStackTrace(event => result = event);
+            let result: InvalidatedEvent|undefined = undefined;
+            debugTracker.onInvalidated(event => result = event);
             const tracker = await adapterFactory!.createDebugAdapterTracker(debugSessionFactory(debugConfigurationFactory()));
             tracker!.onWillStartSession!();
             const stoppedEvent: DebugProtocol.StoppedEvent = {

--- a/src/debug-session/gdbtarget-debug-tracker.test.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.test.ts
@@ -255,12 +255,23 @@ describe('GDBTargetDebugTracker', () => {
             debugTracker.onStackTrace(event => result = event);
             const tracker = await adapterFactory!.createDebugAdapterTracker(debugSessionFactory(debugConfigurationFactory()));
             tracker!.onWillStartSession!();
-            const invalidatedEvent: DebugProtocol.InvalidatedEvent = {
-                event: 'invalidated',
+            const stoppedEvent: DebugProtocol.StoppedEvent = {
+                event: 'stopped',
                 type: 'event',
                 seq: 1,
                 body: {
-                    areas: ['stack']
+                    reason: 'step',
+                    threadId: 1
+                }
+            };
+            tracker!.onDidSendMessage!(stoppedEvent);
+            const invalidatedEvent: DebugProtocol.InvalidatedEvent = {
+                event: 'invalidated',
+                type: 'event',
+                seq: 2,
+                body: {
+                    areas: ['stack'],
+                    threadId: 1
                 }
             };
             tracker!.onDidSendMessage!(invalidatedEvent);

--- a/src/debug-session/gdbtarget-debug-tracker.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.ts
@@ -29,6 +29,7 @@ export interface SessionEvent<T extends DebugProtocol.Event> {
 export type ContinuedEvent = SessionEvent<DebugProtocol.ContinuedEvent>;
 export type StoppedEvent = SessionEvent<DebugProtocol.StoppedEvent>;
 export type MemoryEvent = SessionEvent<DebugProtocol.MemoryEvent>;
+export type InvalidatedEvent = SessionEvent<DebugProtocol.InvalidatedEvent>;
 
 export interface SessionCapabilities {
     session: GDBTargetDebugSession;
@@ -82,6 +83,8 @@ export class GDBTargetDebugTracker {
     private readonly _onMemory: vscode.EventEmitter<MemoryEvent> = new vscode.EventEmitter<MemoryEvent>();
     public readonly onMemory: vscode.Event<MemoryEvent> = this._onMemory.event;
 
+    private readonly _onInvalidated: vscode.EventEmitter<InvalidatedEvent> = new vscode.EventEmitter<InvalidatedEvent>();
+    public readonly onInvalidated: vscode.Event<InvalidatedEvent> = this._onInvalidated.event;
 
     public activate(context: vscode.ExtensionContext) {
         const createDebugAdapterTracker = (session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterTracker> => {
@@ -157,8 +160,8 @@ export class GDBTargetDebugTracker {
                 gdbTargetSession?.filterOutputEvent(event as DebugProtocol.OutputEvent);
                 break;
             case 'invalidated':
-                if (gdbTargetSession && gdbTargetSession.targetState === 'stopped') {
-                    this._onStackTrace.fire({ session: gdbTargetSession } as SessionStackTrace);
+                if (gdbTargetSession) {
+                    this._onInvalidated.fire({ session: gdbTargetSession, event: event as DebugProtocol.InvalidatedEvent });
                 }
                 break;
             case 'memory':

--- a/src/debug-session/gdbtarget-debug-tracker.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.ts
@@ -158,12 +158,12 @@ export class GDBTargetDebugTracker {
                 break;
             case 'invalidated':
                 if (gdbTargetSession && gdbTargetSession.targetState === 'stopped' && event.body && event.body.threadId) {
-                    this._onStackTrace.fire({session: gdbTargetSession, threadId: event.body.threadId, stackFrames: event.body.stackFrameId ?? [], totalFrames: 0});
+                    this._onStackTrace.fire({ session: gdbTargetSession, threadId: event.body.threadId, stackFrames: event.body.stackFrameId ?? [], totalFrames: 0 });
                 }
                 break;
             case 'memory':
                 if (gdbTargetSession) {
-                    this._onMemory.fire({session: gdbTargetSession, event: event as DebugProtocol.MemoryEvent});
+                    this._onMemory.fire({ session: gdbTargetSession, event: event as DebugProtocol.MemoryEvent });
                 }
                 break;
         }

--- a/src/debug-session/gdbtarget-debug-tracker.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.ts
@@ -157,8 +157,8 @@ export class GDBTargetDebugTracker {
                 gdbTargetSession?.filterOutputEvent(event as DebugProtocol.OutputEvent);
                 break;
             case 'invalidated':
-                if (gdbTargetSession && gdbTargetSession.targetState === 'stopped' && event.body && event.body.threadId) {
-                    this._onStackTrace.fire({ session: gdbTargetSession, threadId: event.body.threadId, stackFrames: event.body.stackFrameId ?? [], totalFrames: 0 });
+                if (gdbTargetSession && gdbTargetSession.targetState === 'stopped') {
+                    this._onStackTrace.fire({ session: gdbTargetSession } as SessionStackTrace);
                 }
                 break;
             case 'memory':

--- a/src/debug-session/gdbtarget-debug-tracker.ts
+++ b/src/debug-session/gdbtarget-debug-tracker.ts
@@ -28,6 +28,7 @@ export interface SessionEvent<T extends DebugProtocol.Event> {
 
 export type ContinuedEvent = SessionEvent<DebugProtocol.ContinuedEvent>;
 export type StoppedEvent = SessionEvent<DebugProtocol.StoppedEvent>;
+export type MemoryEvent = SessionEvent<DebugProtocol.MemoryEvent>;
 
 export interface SessionCapabilities {
     session: GDBTargetDebugSession;
@@ -77,6 +78,10 @@ export class GDBTargetDebugTracker {
 
     private readonly _onStackTrace: vscode.EventEmitter<SessionStackTrace> = new vscode.EventEmitter<SessionStackTrace>();
     public readonly onStackTrace: vscode.Event<SessionStackTrace> = this._onStackTrace.event;
+
+    private readonly _onMemory: vscode.EventEmitter<MemoryEvent> = new vscode.EventEmitter<MemoryEvent>();
+    public readonly onMemory: vscode.Event<MemoryEvent> = this._onMemory.event;
+
 
     public activate(context: vscode.ExtensionContext) {
         const createDebugAdapterTracker = (session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterTracker> => {
@@ -150,6 +155,16 @@ export class GDBTargetDebugTracker {
                 break;
             case 'output':
                 gdbTargetSession?.filterOutputEvent(event as DebugProtocol.OutputEvent);
+                break;
+            case 'invalidated':
+                if (gdbTargetSession && gdbTargetSession.targetState === 'stopped' && event.body && event.body.threadId) {
+                    this._onStackTrace.fire({session: gdbTargetSession, threadId: event.body.threadId, stackFrames: event.body.stackFrameId ?? [], totalFrames: 0});
+                }
+                break;
+            case 'memory':
+                if (gdbTargetSession) {
+                    this._onMemory.fire({session: gdbTargetSession, event: event as DebugProtocol.MemoryEvent});
+                }
                 break;
         }
     }

--- a/src/views/component-viewer/component-viewer-base.ts
+++ b/src/views/component-viewer/component-viewer-base.ts
@@ -30,7 +30,7 @@ export interface ScvdCollector {
     getScvdFilePaths(session: GDBTargetDebugSession): Promise<string[]>;
 }
 
-export type UpdateReason = 'sessionChanged' | 'refreshTimer' | 'stackTrace' | 'stackItemChanged' | 'unlockingInstance';
+export type UpdateReason = 'sessionChanged' | 'refreshTimer' | 'stackTrace' | 'stackItemChanged' | 'unlockingInstance' | 'invalidated' | 'memoryEvent';
 
 export interface ComponentViewerInstancesWrapper {
     componentViewerInstance: ComponentViewerInstance;
@@ -332,6 +332,10 @@ export class ComponentViewerBase {
             const session = event.session;
             await this.handleOnMemoryEvent(session);
         });
+        const onInvalidatedDisposable = tracker.onInvalidated(async (event) => {
+            const session = event.session;
+            await this.handleOnInvalidated(session);
+        });
         // clear all disposables on extension deactivation
         this._context.subscriptions.push(
             onWillStopSessionDisposable,
@@ -340,7 +344,8 @@ export class ComponentViewerBase {
             onStackTraceDisposable,
             onDidChangeActiveStackItemDisposable,
             onWillStartSessionDisposable,
-            onMemoryDisposable
+            onMemoryDisposable,
+            onInvalidatedDisposable
         );
     }
 
@@ -357,7 +362,14 @@ export class ComponentViewerBase {
         if (this._activeSession?.session.id !== session.session.id) {
             return;
         }
-        this.schedulePendingUpdate('stackTrace');
+        this.schedulePendingUpdate('memoryEvent');
+    }
+
+    protected async handleOnInvalidated(session: GDBTargetDebugSession): Promise<void> {
+        if (this._activeSession?.session.id !== session.session.id) {
+            return;
+        }
+        this.schedulePendingUpdate('invalidated');
     }
 
     protected async handleOnStackItemChanged(session: GDBTargetDebugSession): Promise<void> {

--- a/src/views/component-viewer/component-viewer-base.ts
+++ b/src/views/component-viewer/component-viewer-base.ts
@@ -328,6 +328,10 @@ export class ComponentViewerBase {
         const onWillStartSessionDisposable = tracker.onWillStartSession(async (session) => {
             await this.handleOnWillStartSession(session);
         });
+        const onMemoryDisposable = tracker.onMemory(async (event) => {
+            const session = event.session;
+            await this.handleOnMemoryEvent(session);
+         });
         // clear all disposables on extension deactivation
         this._context.subscriptions.push(
             onWillStopSessionDisposable,
@@ -335,7 +339,8 @@ export class ComponentViewerBase {
             onDidChangeActiveDebugSessionDisposable,
             onStackTraceDisposable,
             onDidChangeActiveStackItemDisposable,
-            onWillStartSessionDisposable
+            onWillStartSessionDisposable,
+            onMemoryDisposable
         );
     }
 
@@ -345,6 +350,13 @@ export class ComponentViewerBase {
             throw new Error(`${this._viewName}: Received stack trace event for session ${session.session.id} while active session is ${this._activeSession?.session.id}`);
         }
         // Update component viewer instance(s) if active session is stopped
+        this.schedulePendingUpdate('stackTrace');
+    }
+
+    protected async handleOnMemoryEvent(session: GDBTargetDebugSession): Promise<void> {
+        if (this._activeSession?.session.id !== session.session.id) {
+            throw new Error(`${this._viewName}: Received memory event for session ${session.session.id} while active session is ${this._activeSession?.session.id}`);
+        }
         this.schedulePendingUpdate('stackTrace');
     }
 

--- a/src/views/component-viewer/component-viewer-base.ts
+++ b/src/views/component-viewer/component-viewer-base.ts
@@ -355,7 +355,7 @@ export class ComponentViewerBase {
 
     protected async handleOnMemoryEvent(session: GDBTargetDebugSession): Promise<void> {
         if (this._activeSession?.session.id !== session.session.id) {
-            throw new Error(`${this._viewName}: Received memory event for session ${session.session.id} while active session is ${this._activeSession?.session.id}`);
+            return;
         }
         this.schedulePendingUpdate('stackTrace');
     }

--- a/src/views/component-viewer/component-viewer-base.ts
+++ b/src/views/component-viewer/component-viewer-base.ts
@@ -331,7 +331,7 @@ export class ComponentViewerBase {
         const onMemoryDisposable = tracker.onMemory(async (event) => {
             const session = event.session;
             await this.handleOnMemoryEvent(session);
-         });
+        });
         // clear all disposables on extension deactivation
         this._context.subscriptions.push(
             onWillStopSessionDisposable,

--- a/src/views/component-viewer/test/unit/component-viewer-base.test.ts
+++ b/src/views/component-viewer/test/unit/component-viewer-base.test.ts
@@ -20,6 +20,7 @@
  */
 
 import * as vscode from 'vscode';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { GDBTargetDebugTracker } from '../../../../debug-session';
 import type { GDBTargetDebugSession } from '../../../../debug-session/gdbtarget-debug-session';
 import { componentViewerLogger } from '../../../../logger';
@@ -102,6 +103,17 @@ const getReadScvdFiles = (controller: TestClass) =>
 
 // Local test mocks
 type ExpansionEventCallback = (event: vscode.TreeViewExpansionEvent<ScvdGuiInterface>) => void;
+
+const makeMemoryEvent = (): DebugProtocol.MemoryEvent => ({
+    event: 'memory',
+    type: 'event',
+    seq: 1,
+    body: {
+        memoryReference: '0x1234',
+        offset: 0,
+        count: 4,
+    },
+});
 
 const createController = (
     context: vscode.ExtensionContext = extensionContextFactory(),
@@ -310,7 +322,7 @@ describe('ComponentViewerBase', () => {
         await tracker.callbacks.stackTrace?.({ session });
         expect((controller as unknown as { _activeSession?: Session })._activeSession).toBe(session);
 
-        await tracker.callbacks.memory?.({ session });
+        await tracker.callbacks.memory?.({ session, event: makeMemoryEvent() });
 
 
         (controller as unknown as { _activeSession?: Session })._activeSession = session;

--- a/src/views/component-viewer/test/unit/component-viewer-base.test.ts
+++ b/src/views/component-viewer/test/unit/component-viewer-base.test.ts
@@ -115,6 +115,15 @@ const makeMemoryEvent = (): DebugProtocol.MemoryEvent => ({
     },
 });
 
+const makeInvalidatedEvent = (): DebugProtocol.InvalidatedEvent => ({
+    event: 'invalidated',
+    type: 'event',
+    seq: 1,
+    body: {
+        areas: ['variables'],
+    },
+});
+
 const createController = (
     context: vscode.ExtensionContext = extensionContextFactory(),
     provider: ComponentViewerTreeDataProvider = treeDataProviderFactory()
@@ -170,12 +179,12 @@ describe('ComponentViewerBase', () => {
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.lockComponent', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.unlockComponent', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.expandAll', expect.any(Function));
-        // 1 tree view + 2 event listeners + 7 commands + 7 tracker disposables
-        expect(context.subscriptions.length).toBe(17);
+        // 1 tree view + 2 event listeners + 7 commands + 8 tracker disposables
+        expect(context.subscriptions.length).toBe(18);
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.filterTree', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.clearFilter', expect.any(Function));
-        // 1 tree view + 2 event listeners + 7 commands + 7 tracker disposables
-        expect(context.subscriptions.length).toBe(17);
+        // 1 tree view + 2 event listeners + 7 commands + 8 tracker disposables
+        expect(context.subscriptions.length).toBe(18);
     });
 
     it('should fail to activate the test class tree data provider if view is not correctly loaded', async () => {
@@ -323,6 +332,7 @@ describe('ComponentViewerBase', () => {
         expect((controller as unknown as { _activeSession?: Session })._activeSession).toBe(session);
 
         await tracker.callbacks.memory?.({ session, event: makeMemoryEvent() });
+        await tracker.callbacks.invalidated?.({ session, event: makeInvalidatedEvent() });
 
 
         (controller as unknown as { _activeSession?: Session })._activeSession = session;
@@ -395,7 +405,22 @@ describe('ComponentViewerBase', () => {
         const handleOnMemoryEvent = (controller as unknown as { handleOnMemoryEvent: (s: Session) => Promise<void> }).handleOnMemoryEvent.bind(controller);
         await handleOnMemoryEvent(sessionA);
 
-        expect(scheduleSpy).toHaveBeenCalledWith('stackTrace');
+        expect(scheduleSpy).toHaveBeenCalledWith('memoryEvent');
+    });
+
+    it('updates instances on invalidated event', async () => {
+        const sessionA = debugSessionFactory('s1', [], 'stopped');
+
+        (controller as unknown as { _activeSession?: Session })._activeSession = sessionA;
+
+        const scheduleSpy = jest
+            .spyOn(controller as unknown as { schedulePendingUpdate: (reason: UpdateReason) => void }, 'schedulePendingUpdate')
+            .mockImplementation(() => undefined);
+
+        const handleOnInvalidated = (controller as unknown as { handleOnInvalidated: (s: Session) => Promise<void> }).handleOnInvalidated.bind(controller);
+        await handleOnInvalidated(sessionA);
+
+        expect(scheduleSpy).toHaveBeenCalledWith('invalidated');
     });
 
     it('does not update active session when stack item matches the active session', async () => {

--- a/src/views/component-viewer/test/unit/component-viewer-base.test.ts
+++ b/src/views/component-viewer/test/unit/component-viewer-base.test.ts
@@ -38,6 +38,7 @@ const instanceFactory = jest.fn(() => ({
     getGuiTree: jest.fn<ScvdGuiInterface[] | undefined, []>(() => []),
     updateActiveSession: jest.fn(),
     cancelExecution: jest.fn(),
+    setSvdPath: jest.fn(),
 }));
 
 jest.mock('../../component-viewer-instance', () => ({
@@ -157,12 +158,12 @@ describe('ComponentViewerBase', () => {
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.lockComponent', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.unlockComponent', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.expandAll', expect.any(Function));
-        // 1 tree view + 2 event listeners + 7 commands + 6 tracker disposables
-        expect(context.subscriptions.length).toBe(16);
+        // 1 tree view + 2 event listeners + 7 commands + 7 tracker disposables
+        expect(context.subscriptions.length).toBe(17);
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.filterTree', expect.any(Function));
         expect(vscode.commands.registerCommand).toHaveBeenCalledWith('vscode-cmsis-debugger.testClass.clearFilter', expect.any(Function));
-        // 1 tree view + 2 event listeners + 7 commands + 6 tracker disposables
-        expect(context.subscriptions.length).toBe(16);
+        // 1 tree view + 2 event listeners + 7 commands + 7 tracker disposables
+        expect(context.subscriptions.length).toBe(17);
     });
 
     it('should fail to activate the test class tree data provider if view is not correctly loaded', async () => {
@@ -213,6 +214,22 @@ describe('ComponentViewerBase', () => {
         expect(instanceFactory).toHaveBeenCalledTimes(2);
     });
 
+    it('sets svd path from debug configuration when reading scvd files', async () => {
+        const session = debugSessionFactory('s1', ['a.scvd']);
+        (session.session as unknown as { configuration: { definitionPath: string } }).configuration = {
+            definitionPath: '/device.svd',
+        };
+        (controller as unknown as { _activeSession?: Session })._activeSession = session;
+
+        const instance = instanceFactory();
+        instanceFactory.mockImplementationOnce(() => instance);
+
+        const readScvdFiles = getReadScvdFiles(controller);
+        await readScvdFiles(tracker, session);
+
+        expect(instance.setSvdPath).toHaveBeenCalledWith('/device.svd');
+    });
+
     it('skips reading scvd files when no active session is set', async () => {
         const session = debugSessionFactory('s1', ['a.scvd']);
         const readScvdFiles = getReadScvdFiles(controller);
@@ -235,6 +252,7 @@ describe('ComponentViewerBase', () => {
             getGuiTree: jest.fn(() => []),
             updateActiveSession: jest.fn(),
             cancelExecution: jest.fn(),
+            setSvdPath: jest.fn(),
         }));
         const showErrorSpy = jest.spyOn(vscode.window, 'showErrorMessage').mockResolvedValue(undefined);
         const errorSpy = jest.spyOn(componentViewerLogger, 'error');
@@ -291,6 +309,8 @@ describe('ComponentViewerBase', () => {
         (controller as unknown as { _activeSession?: Session })._activeSession = session;
         await tracker.callbacks.stackTrace?.({ session });
         expect((controller as unknown as { _activeSession?: Session })._activeSession).toBe(session);
+
+        await tracker.callbacks.memory?.({ session });
 
 
         (controller as unknown as { _activeSession?: Session })._activeSession = session;
@@ -349,6 +369,21 @@ describe('ComponentViewerBase', () => {
 
         expect(scheduleSpy).toHaveBeenCalledWith('stackItemChanged');
         expect((controller as unknown as { _activeSession?: Session })._activeSession).toBe(sessionA);
+    });
+
+    it('updates instances on memory event', async () => {
+        const sessionA = debugSessionFactory('s1', [], 'stopped');
+
+        (controller as unknown as { _activeSession?: Session })._activeSession = sessionA;
+
+        const scheduleSpy = jest
+            .spyOn(controller as unknown as { schedulePendingUpdate: (reason: UpdateReason) => void }, 'schedulePendingUpdate')
+            .mockImplementation(() => undefined);
+
+        const handleOnMemoryEvent = (controller as unknown as { handleOnMemoryEvent: (s: Session) => Promise<void> }).handleOnMemoryEvent.bind(controller);
+        await handleOnMemoryEvent(sessionA);
+
+        expect(scheduleSpy).toHaveBeenCalledWith('stackTrace');
     });
 
     it('does not update active session when stack item matches the active session', async () => {

--- a/src/views/live-watch/live-watch.test.ts
+++ b/src/views/live-watch/live-watch.test.ts
@@ -114,6 +114,10 @@ describe('LiveWatchTreeDataProvider', () => {
             // Fire onMemory event
             (tracker as any)._onMemory.fire({ session: gdbtargetDebugSession, event: { memoryReference: '0x1234', offset: 0, count: 4 } });
             expect(refreshSpy).toHaveBeenCalled();
+            refreshSpy.mockClear();
+            // Fire onInvalidated event
+            (tracker as any)._onInvalidated.fire({ session: gdbtargetDebugSession, event: { memoryReference: '0x1234', offset: 0, count: 4 } });
+            expect(refreshSpy).toHaveBeenCalled();
         });
 
         it('calls save function when extension is deactivating', async () => {

--- a/src/views/live-watch/live-watch.test.ts
+++ b/src/views/live-watch/live-watch.test.ts
@@ -90,7 +90,7 @@ describe('LiveWatchTreeDataProvider', () => {
             expect((liveWatchTreeDataProvider as any).activeSession).toBeUndefined();
         });
 
-        it('refreshes on stopped event and on onDidChangeActiveStackItem', async () => {
+        it('refreshes on stopped event and on onDidChangeActiveStackItem and onMemory event', async () => {
             const refreshSpy = jest.spyOn(liveWatchTreeDataProvider as any, 'refresh').mockResolvedValue('');
             await liveWatchTreeDataProvider.activate(tracker);
             // Activate session
@@ -102,6 +102,10 @@ describe('LiveWatchTreeDataProvider', () => {
             refreshSpy.mockClear();
             // Fire onDidChangeActiveStackItem event
             (tracker as any)._onDidChangeActiveStackItem.fire({ item: { frameId: 1 } });
+            expect(refreshSpy).toHaveBeenCalled();
+            refreshSpy.mockClear();
+            // Fire onMemory event
+            (tracker as any)._onMemory.fire({ session: gdbtargetDebugSession, event: { memoryReference: '0x1234', offset: 0, count: 4 } });
             expect(refreshSpy).toHaveBeenCalled();
         });
 

--- a/src/views/live-watch/live-watch.ts
+++ b/src/views/live-watch/live-watch.ts
@@ -120,6 +120,9 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
         const onMemory = tracker.onMemory(async (event) => {
             await this.handleOnMemoryEvent(event);
         });
+        const onInvalidated = tracker.onInvalidated(async (event) => {
+            await this.handleOnInvalidated(event);
+        });
         const onContinued = tracker.onContinued(async (event) => {
             await this.handleOnContinued(event.session);
         });
@@ -133,6 +136,7 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
             onStackTrace,
             onWillStopSession,
             onMemory,
+            onInvalidated,
             onContinued,
             onStopped);
         return true;
@@ -174,6 +178,14 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
             return;
         }
         await this._activeSession.setSetExpressionSupportedContext();
+    }
+
+    private async handleOnInvalidated(event: SessionEvent<DebugProtocol.InvalidatedEvent>): Promise<void> {
+        const gdbTargetSession = event.session;
+        if (this._activeSession?.session.id !== gdbTargetSession.session.id) {
+            return;
+        }
+        await this.refresh();
     }
 
     private async addVSCodeCommands(): Promise<boolean> {

--- a/src/views/live-watch/live-watch.ts
+++ b/src/views/live-watch/live-watch.ts
@@ -103,11 +103,12 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
         const onDidChangeActiveDebugSession = tracker.onDidChangeActiveDebugSession(async (session) => await this.handleOnDidChangeActiveDebugSession(session));
         const onWillStartSession =  tracker.onWillStartSession(async (session) => await this.handleOnWillStartSession(session));
         // Using this event because this is when the threadId is available for evaluations
-        const onStackTrace = tracker.onDidChangeActiveStackItem(async (item) => {
+        const onStackItem = tracker.onDidChangeActiveStackItem(async (item) => {
             if ((item.item as vscode.DebugStackFrame).frameId !== undefined) {
                 await this.refresh();
             }
         });
+        const onStackTrace = tracker.onStackTrace(async () => await this.refresh());
         // Clearing active session on closing the session
         const onWillStopSession = tracker.onWillStopSession(async (session) => {
             if (this.activeSession?.session.id && this.activeSession?.session.id === session.session.id) {
@@ -122,6 +123,7 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
         this._context.subscriptions.push(
             onDidChangeActiveDebugSession,
             onWillStartSession,
+            onStackItem,
             onStackTrace,
             onWillStopSession,
             onMemory);

--- a/src/views/live-watch/live-watch.ts
+++ b/src/views/live-watch/live-watch.ts
@@ -16,7 +16,7 @@
 
 import * as vscode from 'vscode';
 import { DebugProtocol } from '@vscode/debugprotocol';
-import { GDBTargetDebugSession, GDBTargetDebugTracker } from '../../debug-session';
+import { GDBTargetDebugSession, GDBTargetDebugTracker, SessionEvent } from '../../debug-session';
 import { vscodeViewExists } from '../../vscode-utils';
 import { logger } from '../..';
 
@@ -116,11 +116,15 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
             await this.refresh();
             await this.save();
         });
+        const onMemory = tracker.onMemory(async (event) => {
+            await this.handleOnMemoryEvent(event);
+        });
         this._context.subscriptions.push(
             onDidChangeActiveDebugSession,
             onWillStartSession,
             onStackTrace,
-            onWillStopSession);
+            onWillStopSession,
+            onMemory);
         return true;
     }
 
@@ -139,6 +143,14 @@ export class LiveWatchTreeDataProvider implements vscode.TreeDataProvider<LiveWa
                 await this.refresh();
             }
         });
+    }
+
+    private async handleOnMemoryEvent(event: SessionEvent<DebugProtocol.MemoryEvent>): Promise<void> {
+        const gdbTargetSession = event.session;
+        if (this._activeSession?.session.id !== gdbTargetSession.session.id) {
+            return;
+        }
+        await this.refresh();
     }
 
     private async addVSCodeCommands(): Promise<boolean> {


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- [#1001 ](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/1001)

## Changes
<!-- List the changes this PR introduces -->

- Tracking both invalidated and memory events in the tracker
- On receiving invalidated events, trigger a stack trace event
- Adding a new memory event in the gdbTracker
- Firing new gdbTracker memory event whenever a memory event is received

P.S. this PR won't work as expected without a cdt-gdb-vscode release, as it requires some changes that I added there

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

