### PR TITLE
Update link to fix markdown lint check

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ from [SEGGER](https://www.segger.com/). Ensure all required drivers and host pla
 
 Related open source projects are:
 
-- The [Open-CMSIS-Pack](https://www.open-cmsis-pack.org/) project includes the CMSIS Debugger extension.
+- The [Open-CMSIS-Pack](https://open-cmsis-pack.github.io/landing/) project includes the CMSIS Debugger extension.
 - [Eclipse® CDT.cloud™](https://eclipse.dev/cdt-cloud/) hosts a number of components and
   best practices for building customizable web-based C/C++ tools.
 - [pyOCD](https://pyocd.io/), a Python based tool and API for debugging, programming, and exploring Arm Cortex®


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->

- Redirect from `https://www.open-cmsis-pack.org/` to `https://open-cmsis-pack.github.io/landing/` disagrees with markdown lint checker and breaks CI.

## Changes
<!-- List the changes this PR introduces -->

- `https://www.open-cmsis-pack.org/` --> `https://open-cmsis-pack.github.io/landing/` in `README.md`

@soumeh01 , do you see a different way to deal with this redirect?

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).

