### PR TITLE
Updated retry delay from 2 seconds to 20

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -74,6 +74,6 @@ jobs:
         if: runner.os == 'Linux'
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          attempt_delay: 2000
+          attempt_delay: 20000
           attempt_limit: 3
           command: npm run check:links

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,7 +90,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          attempt_delay: 2000
+          attempt_delay: 20000
           attempt_limit: 3
           command: npm run check:links
 


### PR DESCRIPTION
## Changes
- Increase markdown link check retry delay from 2s to 20s to improve resilience against temporary network and service availability issues.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

