### PR TITLE
Replace TPIP report timestamp with associated release identifier

### DIFF
--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -7,6 +7,7 @@ on:
       - docs/third-party-licenses.json
       - docs/tpip-header.md
       - scripts/tpip-reporter.ts
+      - package-lock.json
       - '!**/*.md'
       - '!.github/workflows/markdown.yml'
       - '!.github/markdownlint.json'

--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -25,8 +25,9 @@ permissions:
 jobs:
   report:
     permissions:
-      # contents: write  # for Git to git push # disabled until resurrecting direct git push
+      contents: write
       packages: read
+      actions: read
 
     name: Generate report
     runs-on: ubuntu-latest
@@ -52,13 +53,20 @@ jobs:
         run: npm ci
 
       - name: Generate third-party licenses report
-        run: npm run tpip:report
+        id: report
+        run: |
+          npm run tpip:report
+          if git diff --exit-code TPIP.md > /dev/null; then
+            echo "update=0" >> $GITHUB_OUTPUT
+          else
+            echo "update=1" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit changes
-        if: false
-        run: |
-          git config --local user.email "git@github.com"
-          git config --local user.name "GitHub Action"
-          git add TPIP.md
-          git commit -m "Update third-party licenses report [skip ci]"
-          git push
+        if: ${{ steps.report.outputs.update == 1 }}
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321
+        with:
+          message: "Update TPIP report [skip ci]"
+          add: |
+            docs/third-party-licenses.json
+            TPIP.md

--- a/TPIP.md
+++ b/TPIP.md
@@ -1,6 +1,6 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Generated for release: unknwon
+Generated for release: 1.6.1
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|

--- a/TPIP.md
+++ b/TPIP.md
@@ -1,6 +1,6 @@
 # TPIP Report for vscode-cmsis-debugger
 
-Report prepared at: 06/05/2026, 17:17:17
+Generated for release: unknwon
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|

--- a/scripts/tpip-reporter.ts
+++ b/scripts/tpip-reporter.ts
@@ -44,7 +44,13 @@ async function main() {
         .parseSync();
 
     const tpipJson = JSON.parse(fs.readFileSync(json as string, "utf8"));
-    
+
+    let release: string | undefined;
+    if (fs.existsSync('package.json')) {
+        const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+        release = packageJson.version;
+    }
+
     var data: string = '';
     if (header && fs.existsSync(header as string)) {
         data += fs.readFileSync(header as string, "utf8");
@@ -53,7 +59,7 @@ async function main() {
     }
 
     data += '\n';
-    data += `Report prepared at: ${new Date().toLocaleString('en-GB')}\n\n`;
+    data += `Generated for release: ${release ?? 'unknown'}\n\n`;
     data += '| *Package* | *Version* | *Repository* | *License* |\n';
     data += '|---|---|---|---|\n';
 


### PR DESCRIPTION
## Changes
- Record the associated release in the TPIP report instead of a generation timestamp to improve traceability and avoid report diffs caused by timestamp changes on each local generation.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

